### PR TITLE
feat: copier update to parent template v0.3.19

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.3.17
+_commit: v0.3.19
 _src_path: gh:natescherer/postmodern-repo-copiertemplate
 author_name: Nate Scherer
 developer_platform: GitHub

--- a/.github/workflows/release_release_please_action.yml
+++ b/.github/workflows/release_release_please_action.yml
@@ -15,9 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-<<<<<<< before updating
-=======
           token: ${{ secrets.REPO_MAINTENANCE_PAT }}
->>>>>>> after updating
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release_release_please_action.yml
+++ b/.github/workflows/release_release_please_action.yml
@@ -15,5 +15,9 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+<<<<<<< before updating
+=======
+          token: ${{ secrets.REPO_MAINTENANCE_PAT }}
+>>>>>>> after updating
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Copier has applied updates from parent template v0.3.19.

Review and push any needed changes to the `copier-template-update-v0.3.19` branch.