### PR TITLE
feat: copier update to parent template v0.3.37

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.3.33
+_commit: v0.3.37
 _src_path: gh:natescherer/postmodern-repo-copiertemplate
 author_name: Nate Scherer
 developer_platform: GitHub

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ It is highly encouraged for you to take this template and make your own child te
   - Markdown linting via [markdownlint](https://github.com/DavidAnson/markdownlint)
   - Python linting and formatting via [Ruff](https://github.com/astral-sh/ruff)
   - Spell checking via [cSpell](https://cspell.org/)
+<<<<<<< before updating
+=======
+  - TOML linting via [taplo](https://github.com/tamasfe/taplo)
+>>>>>>> after updating
   - YAML formatting via [Prettier](https://prettier.io/)
   - YAML linting via [yamllint](https://github.com/adrienverge/yamllint)
 


### PR DESCRIPTION
Copier has applied updates from parent template v0.3.37.

Review and push any needed changes to the `copier-template-update-v0.3.37` branch.