### PR TITLE
feat: copier update to parent template v0.3.40

### DIFF
--- a/.config/requirements.txt
+++ b/.config/requirements.txt
@@ -1,7 +1,10 @@
 copier==9.7.1
 copier-templates-extensions==0.3.1
 githubkit==0.12.13
+<<<<<<< before updating
 invoke==2.2.0
+=======
+>>>>>>> after updating
 jinja2-shell-extension==2.1.1
 jinja2-time==0.2.0
 pip==25.1.1

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.3.39
+_commit: v0.3.40
 _src_path: gh:natescherer/postmodern-repo-copiertemplate
 author_name: Nate Scherer
 developer_platform: GitHub

--- a/.github/workflows/update_copier_parent_template.yml
+++ b/.github/workflows/update_copier_parent_template.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: jdx/mise-action@v2
         with:
           experimental: true
+<<<<<<< before updating
       - name: Get New Template Version
         id: get_ver
         run: |
@@ -24,6 +25,8 @@ jobs:
           OUTPUT=$(copier update --skip-answered --pretend --trust 2>&1)
           NEW_VERSION=${OUTPUT##* }
           echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+=======
+>>>>>>> after updating
       - name: Run Copier Update
         run: |
           source .venv/bin/activate

--- a/hk.pkl
+++ b/hk.pkl
@@ -32,10 +32,16 @@ local linters = new Mapping<String, Step> {
         stage = "*.toml"
         check = "taplo check {{ files }}"
         fix = "taplo format {{ files }}"
+<<<<<<< before updating
     } 
     ["typos"] {
         glob = "*"
         exclude = "{CHANGELOG.md}"
+=======
+    }
+    ["typos"] {
+        glob = "*"
+>>>>>>> after updating
         check = "typos -c .config/typos.toml {{files}}"
     }
     ["yamllint"] {
@@ -62,7 +68,11 @@ hooks {
         steps {
             ...linters // add all linters defined above
         }
+<<<<<<< before updating
     }
+=======
+    }x1
+>>>>>>> after updating
     // "fix" and "check" are special steps for `hk fix` and `hk check` commands
     ["fix"] {
         fix = true

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/update-copier-parent-template.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/update-copier-parent-template.yml
@@ -37,14 +37,12 @@ stages:
             failOnStderr: true
             displayName: Install Mise
           - pwsh: |
-              . .venv/bin/Activate.ps1
               $Output = copier update --skip-answered --pretend --trust 2>&1
               $NewVersion = $Output[0].ToString().Split(" ")[-1]
               Write-Host "##vso[task.setvariable variable=NEW_VERSION;]$NewVersion"
             failOnStderr: true
             displayName: Get New Template Version
           - pwsh: |
-              . .venv/bin/Activate.ps1
               copier update --skip-answered --trust
             failOnStderr: false # Copier writes to stderr normally
             displayName: Run Copier Update

--- a/template/{% if using_github %}.github{% endif %}/workflows/update_copier_parent_template.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/update_copier_parent_template.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: jdx/mise-action@v2
         with:
           experimental: true
+<<<<<<< before updating
       - name: Get New Template Version
         id: get_ver
         run: |
@@ -24,6 +25,8 @@ jobs:
           OUTPUT=$(copier update --skip-answered --pretend --trust 2>&1)
           NEW_VERSION=${OUTPUT##* }
           echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+=======
+>>>>>>> after updating
       - name: Run Copier Update
         run: |
           source .venv/bin/activate


### PR DESCRIPTION
Copier has applied updates from parent template v0.3.40.

Review and push any needed changes to the `copier-template-update-v0.3.40` branch.