### PR TITLE
feat: copier update to parent template v0.3.41

### DIFF
--- a/.config/requirements.txt
+++ b/.config/requirements.txt
@@ -1,7 +1,10 @@
 copier==9.7.1
 copier-templates-extensions==0.3.1
 githubkit==0.12.13
+<<<<<<< before updating
 invoke==2.2.0
+=======
+>>>>>>> after updating
 jinja2-shell-extension==2.1.1
 jinja2-time==0.2.0
 pip==25.1.1

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.3.39
+_commit: v0.3.41
 _src_path: gh:natescherer/postmodern-repo-copiertemplate
 author_name: Nate Scherer
 developer_platform: GitHub

--- a/hk.pkl
+++ b/hk.pkl
@@ -32,10 +32,16 @@ local linters = new Mapping<String, Step> {
         stage = "*.toml"
         check = "taplo check {{ files }}"
         fix = "taplo format {{ files }}"
+<<<<<<< before updating
     } 
     ["typos"] {
         glob = "*"
         exclude = "{CHANGELOG.md}"
+=======
+    }
+    ["typos"] {
+        glob = "*"
+>>>>>>> after updating
         check = "typos -c .config/typos.toml {{files}}"
     }
     ["yamllint"] {
@@ -62,7 +68,11 @@ hooks {
         steps {
             ...linters // add all linters defined above
         }
+<<<<<<< before updating
     }
+=======
+    }x1
+>>>>>>> after updating
     // "fix" and "check" are special steps for `hk fix` and `hk check` commands
     ["fix"] {
         fix = true


### PR DESCRIPTION
Copier has applied updates from parent template v0.3.41.

Review and push any needed changes to the `copier-template-update-v0.3.41` branch.