### PR TITLE
feat: copier update to parent template v0.3.42

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.3.39
+_commit: v0.3.42
 _src_path: gh:natescherer/postmodern-repo-copiertemplate
 author_name: Nate Scherer
 developer_platform: GitHub

--- a/hk.pkl
+++ b/hk.pkl
@@ -32,10 +32,16 @@ local linters = new Mapping<String, Step> {
         stage = "*.toml"
         check = "taplo check {{ files }}"
         fix = "taplo format {{ files }}"
+<<<<<<< before updating
     } 
     ["typos"] {
         glob = "*"
         exclude = "{CHANGELOG.md}"
+=======
+    }
+    ["typos"] {
+        glob = "*"
+>>>>>>> after updating
         check = "typos -c .config/typos.toml {{files}}"
     }
     ["yamllint"] {

--- a/hk.pkl
+++ b/hk.pkl
@@ -32,16 +32,9 @@ local linters = new Mapping<String, Step> {
         stage = "*.toml"
         check = "taplo check {{ files }}"
         fix = "taplo format {{ files }}"
-<<<<<<< before updating
-    } 
-    ["typos"] {
-        glob = "*"
-        exclude = "{CHANGELOG.md}"
-=======
     }
     ["typos"] {
         glob = "*"
->>>>>>> after updating
         check = "typos -c .config/typos.toml {{files}}"
     }
     ["yamllint"] {


### PR DESCRIPTION
Copier has applied updates from parent template v0.3.42.

Review and push any needed changes to the `copier-template-update-v0.3.42` branch.