### PR TITLE
feat: copier update to parent template v0.3.47

### DIFF
--- a/.config/.yamllint.yaml
+++ b/.config/.yamllint.yaml
@@ -24,5 +24,9 @@ rules:
     extra-allowed: ["{|}"]
   truthy:
     ignore:
+<<<<<<< before updating
       - "**/workflows/*.yml"
+=======
+      - "**/workflows/*.yml.*"
+>>>>>>> after updating
       - "**/workflows/*.yml{% endif %}"

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.3.42
+_commit: v0.3.47
 _src_path: gh:natescherer/postmodern-repo-copiertemplate
 author_name: Nate Scherer
 developer_platform: GitHub

--- a/.github/workflows/tests_pr_tests.yml
+++ b/.github/workflows/tests_pr_tests.yml
@@ -20,7 +20,11 @@ jobs:
         with:
           experimental: true
       - name: hk check
+<<<<<<< before updating
         run: hk check --all
+=======
+        run: hk check --from-ref main
+>>>>>>> after updating
       - name: Example Tests
         run: |
           FILE=README.md

--- a/template/{% if using_github %}.github{% endif %}/workflows/tests_pr_tests.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/tests_pr_tests.yml
@@ -20,7 +20,11 @@ jobs:
         with:
           experimental: true
       - name: hk check
+<<<<<<< before updating
         run: hk check --all
+=======
+        run: hk check --from-ref main
+>>>>>>> after updating
       - name: Example Tests
         run: |
           FILE=README.md


### PR DESCRIPTION
Copier has applied updates from parent template v0.3.47.

Review and push any needed changes to the `copier-template-update-v0.3.47` branch.