### PR TITLE
fix: fail fast when az/gh CLI or the azure-devops extension are missing

### DIFF
--- a/scripts/integration_test_azdo.py
+++ b/scripts/integration_test_azdo.py
@@ -82,6 +82,46 @@ def az_value(*args: str) -> str:
     return run("az", *args, capture=True).stdout.strip()
 
 
+def check_az_installed() -> None:
+    """Verify the `az` CLI is actually resolvable on PATH.
+
+    Without this, a missing `az` surfaces as a raw FileNotFoundError traceback from
+    deep inside the first real `az` call instead of a clear message up front.
+
+    Raises:
+        SystemExit: if `az` can't be found.
+
+    """
+    if shutil.which("az") is None:
+        raise SystemExit(
+            "Azure CLI ('az') not found on PATH. Install it: "
+            "https://learn.microsoft.com/cli/azure/install-azure-cli"
+        )
+
+
+def check_azure_devops_extension() -> None:
+    """Verify the azure-devops CLI extension is installed.
+
+    `az devops`/`az repos`/`az pipelines` commands, if the extension isn't installed,
+    prompt interactively to install it ("Do you want to install it now? (Y/n):") --
+    which just hangs forever with no stdin attached (e.g. under `mise run` or in CI).
+    Checking via `az extension list` first (a core command that doesn't itself need
+    the extension) avoids ever triggering that prompt.
+
+    Raises:
+        SystemExit: if the extension isn't installed.
+
+    """
+    installed = az_value(
+        "extension", "list", "--query", "[?name=='azure-devops'].name", "-o", "tsv"
+    )
+    if not installed:
+        raise SystemExit(
+            "Azure CLI extension 'azure-devops' is not installed. Install it: "
+            "az extension add --name azure-devops"
+        )
+
+
 def check_access(org_url: str, project: str) -> None:
     """Verify the active az session can actually see the target project.
 
@@ -300,8 +340,8 @@ def main() -> None:
     """Parse args, then create, verify, and (if requested) clean up a test repo.
 
     Raises:
-        SystemExit: if --org/--project are missing, or left at their placeholder
-            value.
+        SystemExit: if `az` or its azure-devops extension aren't installed, or
+            --org/--project are missing or left at their placeholder value.
 
     """
     parser = argparse.ArgumentParser(description=__doc__)
@@ -338,6 +378,9 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
+
+    check_az_installed()
+    check_azure_devops_extension()
 
     if not args.org or not args.project:
         raise SystemExit(

--- a/scripts/integration_test_github.py
+++ b/scripts/integration_test_github.py
@@ -68,6 +68,22 @@ def gh_value(*args: str) -> str:
     return run("gh", *args, capture=True).stdout.strip()
 
 
+def check_gh_installed() -> None:
+    """Verify the `gh` CLI is actually resolvable on PATH.
+
+    Without this, a missing `gh` surfaces as a raw FileNotFoundError traceback from
+    deep inside the first real `gh` call instead of a clear message up front.
+
+    Raises:
+        SystemExit: if `gh` can't be found.
+
+    """
+    if shutil.which("gh") is None:
+        raise SystemExit(
+            "GitHub CLI ('gh') not found on PATH. Install it: https://cli.github.com"
+        )
+
+
 def check_scopes() -> None:
     """Verify the active gh token has every scope this script needs.
 
@@ -290,6 +306,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    check_gh_installed()
     check_scopes()
 
     owner = gh_value("api", "user", "--jq", ".login")

--- a/template/{% if is_template %}scripts{% endif %}/integration_test_azdo.py
+++ b/template/{% if is_template %}scripts{% endif %}/integration_test_azdo.py
@@ -82,6 +82,46 @@ def az_value(*args: str) -> str:
     return run("az", *args, capture=True).stdout.strip()
 
 
+def check_az_installed() -> None:
+    """Verify the `az` CLI is actually resolvable on PATH.
+
+    Without this, a missing `az` surfaces as a raw FileNotFoundError traceback from
+    deep inside the first real `az` call instead of a clear message up front.
+
+    Raises:
+        SystemExit: if `az` can't be found.
+
+    """
+    if shutil.which("az") is None:
+        raise SystemExit(
+            "Azure CLI ('az') not found on PATH. Install it: "
+            "https://learn.microsoft.com/cli/azure/install-azure-cli"
+        )
+
+
+def check_azure_devops_extension() -> None:
+    """Verify the azure-devops CLI extension is installed.
+
+    `az devops`/`az repos`/`az pipelines` commands, if the extension isn't installed,
+    prompt interactively to install it ("Do you want to install it now? (Y/n):") --
+    which just hangs forever with no stdin attached (e.g. under `mise run` or in CI).
+    Checking via `az extension list` first (a core command that doesn't itself need
+    the extension) avoids ever triggering that prompt.
+
+    Raises:
+        SystemExit: if the extension isn't installed.
+
+    """
+    installed = az_value(
+        "extension", "list", "--query", "[?name=='azure-devops'].name", "-o", "tsv"
+    )
+    if not installed:
+        raise SystemExit(
+            "Azure CLI extension 'azure-devops' is not installed. Install it: "
+            "az extension add --name azure-devops"
+        )
+
+
 def check_access(org_url: str, project: str) -> None:
     """Verify the active az session can actually see the target project.
 
@@ -300,8 +340,8 @@ def main() -> None:
     """Parse args, then create, verify, and (if requested) clean up a test repo.
 
     Raises:
-        SystemExit: if --org/--project are missing, or left at their placeholder
-            value.
+        SystemExit: if `az` or its azure-devops extension aren't installed, or
+            --org/--project are missing or left at their placeholder value.
 
     """
     parser = argparse.ArgumentParser(description=__doc__)
@@ -338,6 +378,9 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
+
+    check_az_installed()
+    check_azure_devops_extension()
 
     if not args.org or not args.project:
         raise SystemExit(

--- a/template/{% if is_template %}scripts{% endif %}/integration_test_github.py
+++ b/template/{% if is_template %}scripts{% endif %}/integration_test_github.py
@@ -68,6 +68,22 @@ def gh_value(*args: str) -> str:
     return run("gh", *args, capture=True).stdout.strip()
 
 
+def check_gh_installed() -> None:
+    """Verify the `gh` CLI is actually resolvable on PATH.
+
+    Without this, a missing `gh` surfaces as a raw FileNotFoundError traceback from
+    deep inside the first real `gh` call instead of a clear message up front.
+
+    Raises:
+        SystemExit: if `gh` can't be found.
+
+    """
+    if shutil.which("gh") is None:
+        raise SystemExit(
+            "GitHub CLI ('gh') not found on PATH. Install it: https://cli.github.com"
+        )
+
+
 def check_scopes() -> None:
     """Verify the active gh token has every scope this script needs.
 
@@ -290,6 +306,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    check_gh_installed()
     check_scopes()
 
     owner = gh_value("api", "user", "--jq", ".login")


### PR DESCRIPTION
Without these, a missing CLI or extension surfaced as a raw traceback (or, for the az extension prompt, an indefinite hang with no stdin attached) deep inside the first real command instead of a clear error up front.