### PR TITLE
feat: remind users to set CI secrets after copy, add opt-in provision…

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -545,6 +545,24 @@ _tasks:
 _message_after_copy: |-
   {%- if using_github and not should_set_repo_settings -%}
     Repo settings (labels, merge options, branch protection) are not being applied automatically. See the 'Manual Repo Settings' page in documentation for how to replicate them by hand, or install the Settings GitHub App (https://github.com/apps/settings) and it will pick up the already-generated .github/settings.yml on its own.
+
+  {% endif -%}
+  {%- if using_github -%}
+  Before CI works, add these as GitHub Actions secrets (Settings > Secrets and variables > Actions):
+    - REPO_MAINTENANCE_PAT
+    - APPRISE_URL
+  {%- if is_template and integration_test_scheduled %}
+    - INTEGRATION_TEST_PAT
+    - AZURE_DEVOPS_EXT_PAT
+  {%- endif %}
+  Run `mise run provision-secrets` for a guided, masked prompt, or set them by hand -- see docs/token_permissions.md for what each one needs.
+  {%- elif using_azdo -%}
+  Before CI works, add these as secret Azure DevOps pipeline variables (Pipelines > Library):
+    - APPRISE_URL
+  {%- if is_template and integration_test_scheduled %}
+    - AZURE_DEVOPS_EXT_PAT
+  {%- endif %}
+  Run `mise run provision-secrets` for a guided, masked prompt, or set them by hand -- see docs/token_permissions.md for what each one needs.
   {%- endif %}
 
 _message_after_update: |-

--- a/template/mise.toml.jinja
+++ b/template/mise.toml.jinja
@@ -28,6 +28,29 @@ run = "copier update --answers-file .config/copier-answers.yml --skip-answered -
 
 [tasks.docs-server]
 run = "zensical serve"
+
+[tasks.provision-secrets]
+# Opt-in and separate from _tasks on purpose -- see docs/token_permissions.md. `raw`
+# gives gh/az direct terminal control so each CLI's own masked prompt (gh's
+# Prompter.Password, az's knack.prompting.prompt_pass) reads the value straight from
+# the terminal -- it never touches a command-line argument, mise's own logging, or a
+# script of ours.
+raw = true
+run = [
+{%- if using_github %}
+  "gh secret set REPO_MAINTENANCE_PAT",
+  "gh secret set APPRISE_URL",
+{%- if is_template and integration_test_scheduled %}
+  "gh secret set INTEGRATION_TEST_PAT",
+  "gh secret set AZURE_DEVOPS_EXT_PAT",
+{%- endif %}
+{%- elif using_azdo %}
+  "az pipelines variable create --name APPRISE_URL --pipeline-name \"[{{ repo_name }}] copier-update-check\" --secret true --allow-override true --org https://dev.azure.com/{{ azdo_org }}/ --project \"{{ azdo_project }}\"",
+{%- if is_template and integration_test_scheduled %}
+  "az pipelines variable create --name AZURE_DEVOPS_EXT_PAT --pipeline-name \"[{{ repo_name }}] integration_test\" --secret true --allow-override true --org https://dev.azure.com/{{ azdo_org }}/ --project \"{{ azdo_project }}\"",
+{%- endif %}
+{%- endif %}
+]
 {%- if is_template %}
 
 [tasks.test]

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -558,6 +558,24 @@ _tasks:
 _message_after_copy: |-
   {%- if using_github and not should_set_repo_settings -%}
     Repo settings (labels, merge options, branch protection) are not being applied automatically. See the 'Manual Repo Settings' page in documentation for how to replicate them by hand, or install the Settings GitHub App (https://github.com/apps/settings) and it will pick up the already-generated .github/settings.yml on its own.
+
+  {% endif -%}
+  {%- if using_github -%}
+  Before CI works, add these as GitHub Actions secrets (Settings > Secrets and variables > Actions):
+    - REPO_MAINTENANCE_PAT
+    - APPRISE_URL
+  {%- if is_template and integration_test_scheduled %}
+    - INTEGRATION_TEST_PAT
+    - AZURE_DEVOPS_EXT_PAT
+  {%- endif %}
+  Run `mise run provision-secrets` for a guided, masked prompt, or set them by hand -- see docs/token_permissions.md for what each one needs.
+  {%- elif using_azdo -%}
+  Before CI works, add these as secret Azure DevOps pipeline variables (Pipelines > Library):
+    - APPRISE_URL
+  {%- if is_template and integration_test_scheduled %}
+    - AZURE_DEVOPS_EXT_PAT
+  {%- endif %}
+  Run `mise run provision-secrets` for a guided, masked prompt, or set them by hand -- see docs/token_permissions.md for what each one needs.
   {%- endif %}
 
 _message_after_update: |-

--- a/template/{% if is_template %}docs{% endif %}/token_permissions.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/token_permissions.md.jinja
@@ -3,6 +3,19 @@
 This doc details the minimum scopes/permissions needed to use this template, along with reasons
 why. Neither platform requires a prompted Personal Access Token for repo setup anymore -- both use
 the platform's own CLI session instead (`gh auth login` / `az login`).
+
+Once you've created each secret/token below, run `mise run provision-secrets`: each value is
+entered via that platform's own CLI prompt (`gh secret set` / `az pipelines variable create`),
+masked as you type and never passed as a command-line argument. It's opt-in and safe to re-run
+any time, e.g. to rotate a token.
+
+## Update Notifications
+
+Both platforms' Copier update-check job needs a secret/variable called **APPRISE_URL**. Unlike the
+tokens below, it isn't a scope to grant -- it's an [Apprise](https://github.com/caronc/apprise)
+notification URL pointing at wherever you want update notifications sent (email, Slack, Discord,
+ntfy, Pushover, and 80+ others -- see Apprise's own docs for the URL format for your service of
+choice).
 {%- if using_github %}
 
 ## GitHub


### PR DESCRIPTION
…ing task

Secret/token creation can't be automated by _tasks, so this was previously silent -- a generated project's CI just failed later with no explanation. Adds a post-copy reminder plus `mise run provision-secrets`, an opt-in task that masked-prompts for each needed secret and pushes it via `gh secret set` / `az pipelines variable create --secret`, keeping values out of argv, shell history, and process listings.