### PR TITLE
feat: require PR validation to pass before merge, with admin override

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -504,6 +504,81 @@ _tasks:
       --project "{{ azdo_project }}"
     when: *when_copy_set_repo_settings_azdo
 
+  # Requires the pr_validation build to pass before a PR can be completed, and lets
+  # Project Administrators override that when completing a PR (mirrors GitHub's
+  # admin bypass_actors entry in settings.yml.jinja). `az repos policy` has no flag
+  # for the override part -- it's a branch-level security permission instead, set
+  # via the raw security-namespace API since `az repos`/`az devops` has no
+  # higher-level command for it. Namespace ID, permission bit, and token format
+  # aren't in Microsoft's own CLI docs; cross-checked against
+  # https://github.com/Azure/azure-devops-cli-extension/blob/master/doc/security_tokens.md
+  # and https://devblogs.microsoft.com/devops/git-repo-tokens-for-the-security-service/.
+  - command:
+      - python
+      - -c
+      - |
+        import json, subprocess
+
+        ORG = "https://dev.azure.com/{{ azdo_org }}/"
+        PROJECT = "{{ azdo_project }}"
+
+
+        def az(*args, project=True):
+            cmd = ["az", *args, "--org", ORG]
+            if project:
+                cmd += ["--project", PROJECT]
+            return subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
+
+
+        repo_id = az(
+            "repos", "show", "--repository", "{{ repo_name }}", "--query", "id", "-o", "tsv"
+        ).strip()
+        pipeline_id = az(
+            "pipelines", "show", "--name", "[{{ repo_name }}] pr_validation",
+            "--query", "id", "-o", "tsv",
+        ).strip()
+
+        subprocess.run(
+            [
+                "az", "repos", "policy", "build", "create",
+                "--blocking", "true",
+                "--enabled", "true",
+                "--branch", "main",
+                "--build-definition-id", pipeline_id,
+                "--display-name", "PR Validation",
+                "--manual-queue-only", "false",
+                "--queue-on-source-update-only", "false",
+                "--valid-duration", "0",
+                "--repository-id", repo_id,
+                "--org", ORG,
+                "--project", PROJECT,
+            ],
+            check=True,
+        )
+
+        project_id = az("devops", "project", "show", "--query", "id", "-o", "tsv").strip()
+        groups = json.loads(az("devops", "security", "group", "list", "-o", "json"))
+        descriptor = next(
+            g["descriptor"]
+            for g in groups["graphGroups"]
+            if g["displayName"] == "Project Administrators"
+        )
+        # refs/heads/main, UTF-16LE hex-encoded per character -- Azure DevOps's Git
+        # ACL token format for a specific branch.
+        token = f"repoV2/{project_id}/{repo_id}/refs/heads/6d00610069006e00"
+        subprocess.run(
+            [
+                "az", "devops", "security", "permission", "update",
+                "--namespace-id", "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87",  # Git Repositories
+                "--subject", descriptor,
+                "--token", token,
+                "--allow-bit", "32768",  # PullRequestBypassPolicy
+                "--org", ORG,
+            ],
+            check=True,
+        )
+    when: *when_copy_set_repo_settings_azdo
+
   # Creates Azure Pipeline for release
   - command: >-
       az pipelines create

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -517,6 +517,81 @@ _tasks:
       --project "{{ azdo_project }}"
     when: *when_copy_set_repo_settings_azdo
 
+  # Requires the pr_validation build to pass before a PR can be completed, and lets
+  # Project Administrators override that when completing a PR (mirrors GitHub's
+  # admin bypass_actors entry in settings.yml.jinja). `az repos policy` has no flag
+  # for the override part -- it's a branch-level security permission instead, set
+  # via the raw security-namespace API since `az repos`/`az devops` has no
+  # higher-level command for it. Namespace ID, permission bit, and token format
+  # aren't in Microsoft's own CLI docs; cross-checked against
+  # https://github.com/Azure/azure-devops-cli-extension/blob/master/doc/security_tokens.md
+  # and https://devblogs.microsoft.com/devops/git-repo-tokens-for-the-security-service/.
+  - command:
+      - python
+      - -c
+      - |
+        import json, subprocess
+
+        ORG = "https://dev.azure.com/{{ azdo_org }}/"
+        PROJECT = "{{ azdo_project }}"
+
+
+        def az(*args, project=True):
+            cmd = ["az", *args, "--org", ORG]
+            if project:
+                cmd += ["--project", PROJECT]
+            return subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
+
+
+        repo_id = az(
+            "repos", "show", "--repository", "{{ repo_name }}", "--query", "id", "-o", "tsv"
+        ).strip()
+        pipeline_id = az(
+            "pipelines", "show", "--name", "[{{ repo_name }}] pr_validation",
+            "--query", "id", "-o", "tsv",
+        ).strip()
+
+        subprocess.run(
+            [
+                "az", "repos", "policy", "build", "create",
+                "--blocking", "true",
+                "--enabled", "true",
+                "--branch", "main",
+                "--build-definition-id", pipeline_id,
+                "--display-name", "PR Validation",
+                "--manual-queue-only", "false",
+                "--queue-on-source-update-only", "false",
+                "--valid-duration", "0",
+                "--repository-id", repo_id,
+                "--org", ORG,
+                "--project", PROJECT,
+            ],
+            check=True,
+        )
+
+        project_id = az("devops", "project", "show", "--query", "id", "-o", "tsv").strip()
+        groups = json.loads(az("devops", "security", "group", "list", "-o", "json"))
+        descriptor = next(
+            g["descriptor"]
+            for g in groups["graphGroups"]
+            if g["displayName"] == "Project Administrators"
+        )
+        # refs/heads/main, UTF-16LE hex-encoded per character -- Azure DevOps's Git
+        # ACL token format for a specific branch.
+        token = f"repoV2/{project_id}/{repo_id}/refs/heads/6d00610069006e00"
+        subprocess.run(
+            [
+                "az", "devops", "security", "permission", "update",
+                "--namespace-id", "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87",  # Git Repositories
+                "--subject", descriptor,
+                "--token", token,
+                "--allow-bit", "32768",  # PullRequestBypassPolicy
+                "--org", ORG,
+            ],
+            check=True,
+        )
+    when: *when_copy_set_repo_settings_azdo
+
   # Creates Azure Pipeline for release
   - command: >-
       az pipelines create

--- a/template/{% if is_template %}docs{% endif %}/manual_repo_settings.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/manual_repo_settings.md.jinja
@@ -39,6 +39,12 @@ Under **Settings > Rules > Rulesets**, create a new ruleset:
         - Require review from Code Owners: off
         - Require approval of the most recent reviewable push: off
         - Require conversation resolution before merging: off
+    - **Require status checks to pass**, with:
+        - Require branches to be up to date before merging: on
+        - Status check: `tests` (the job in `[Test] PR Validation`)
+- Bypass list: add **Repository admin**, with bypass mode **Pull requests only** -- this lets
+  repo admins use the "Merge without waiting for requirements to be met" button instead of being
+  blocked entirely.
 {%- if zensical_ghpages %}
 
 ## GitHub Pages Environment

--- a/template/{% if using_github %}.github{% endif %}/settings.yml.jinja
+++ b/template/{% if using_github %}.github{% endif %}/settings.yml.jinja
@@ -86,7 +86,15 @@ rulesets:
   - name: default-branch-protection
     target: branch
     enforcement: active
-    bypass_actors: []
+    # actor_id 5 = the built-in "admin" repository role (undocumented by GitHub, but
+    # widely confirmed: https://github.com/github/rest-api-description/issues/4406).
+    # bypass_mode "pull_request" only lets an admin skip requirements when merging a
+    # PR (the "Merge without waiting for requirements" button) -- it doesn't grant a
+    # direct push past this ruleset the way "always" would.
+    bypass_actors:
+      - actor_type: RepositoryRole
+        actor_id: 5
+        bypass_mode: pull_request
     conditions:
       ref_name:
         exclude: []
@@ -101,6 +109,17 @@ rulesets:
           require_last_push_approval: false
           required_approving_review_count: 0
           required_review_thread_resolution: false
+      - type: required_status_checks
+        parameters:
+          do_not_enforce_on_create: true
+          # Matches the AzDO side's forced behavior (queue-on-source-update-only
+          # false requires valid-duration 0, i.e. "recheck immediately when the
+          # target branch updates") -- keeps both platforms equally strict.
+          strict_required_status_checks_policy: true
+          required_status_checks:
+            # Job id from test-pr_validation.yml.jinja's "tests" job (no `name:` set,
+            # so its check run name is the job id verbatim).
+            - context: tests
 {%- if zensical_ghpages %}
 
 environments:


### PR DESCRIPTION
Adds a required status check (GitHub ruleset) / blocking build-validation policy (Azure Pipelines) on the pr_validation check for the default branch, so a failing or pending run blocks merge on both platforms. Repo admins (GitHub RepositoryRole, AzDO Project Administrators) get bypass access scoped to completing a PR, not direct pushes, so they can still merge in an emergency without disabling the requirement for everyone else.