### PR TITLE
feat: enable auto-merge on all repos, not just Zensical ones

### DIFF
--- a/template/{% if using_github %}.github{% endif %}/settings.yml.jinja
+++ b/template/{% if using_github %}.github{% endif %}/settings.yml.jinja
@@ -8,9 +8,7 @@ repository:
   private: {% if is_public %}false{% else %}true{% endif %}
 
   # Deliberate overrides of GitHub's defaults
-  {%- if zensical_repo %}
   allow_auto_merge: true
-  {%- endif %}
   allow_merge_commit: false
   allow_rebase_merge: false
   delete_branch_on_merge: true


### PR DESCRIPTION
Now that PR merges can be blocked on the pr_validation check, auto-merge is useful everywhere, not just repos with the docs-versioning workflow that originally motivated it.