### PR TITLE
fix: resolve az via shutil.which() in the AzDO PR-policy task

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -517,14 +517,20 @@ _tasks:
       - python
       - -c
       - |
-        import json, subprocess
+        import json, shutil, subprocess
 
         ORG = "https://dev.azure.com/{{ azdo_org }}/"
         PROJECT = "{{ azdo_project }}"
+        # az is an az.cmd batch wrapper on Windows, not a real .exe -- subprocess with
+        # shell=False (the default, used throughout below) won't find it from the bare
+        # name alone, failing with FileNotFoundError: [WinError 2]. which() finds the
+        # actual resolvable path on any platform, sidestepping that gap without
+        # needing shell=True.
+        AZ = shutil.which("az") or "az"
 
 
         def az(*args, project=True):
-            cmd = ["az", *args, "--org", ORG]
+            cmd = [AZ, *args, "--org", ORG]
             if project:
                 cmd += ["--project", PROJECT]
             return subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
@@ -540,7 +546,7 @@ _tasks:
 
         subprocess.run(
             [
-                "az", "repos", "policy", "build", "create",
+                AZ, "repos", "policy", "build", "create",
                 "--blocking", "true",
                 "--enabled", "true",
                 "--branch", "main",
@@ -568,7 +574,7 @@ _tasks:
         token = f"repoV2/{project_id}/{repo_id}/refs/heads/6d00610069006e00"
         subprocess.run(
             [
-                "az", "devops", "security", "permission", "update",
+                AZ, "devops", "security", "permission", "update",
                 "--namespace-id", "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87",  # Git Repositories
                 "--subject", descriptor,
                 "--token", token,

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -530,14 +530,20 @@ _tasks:
       - python
       - -c
       - |
-        import json, subprocess
+        import json, shutil, subprocess
 
         ORG = "https://dev.azure.com/{{ azdo_org }}/"
         PROJECT = "{{ azdo_project }}"
+        # az is an az.cmd batch wrapper on Windows, not a real .exe -- subprocess with
+        # shell=False (the default, used throughout below) won't find it from the bare
+        # name alone, failing with FileNotFoundError: [WinError 2]. which() finds the
+        # actual resolvable path on any platform, sidestepping that gap without
+        # needing shell=True.
+        AZ = shutil.which("az") or "az"
 
 
         def az(*args, project=True):
-            cmd = ["az", *args, "--org", ORG]
+            cmd = [AZ, *args, "--org", ORG]
             if project:
                 cmd += ["--project", PROJECT]
             return subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
@@ -553,7 +559,7 @@ _tasks:
 
         subprocess.run(
             [
-                "az", "repos", "policy", "build", "create",
+                AZ, "repos", "policy", "build", "create",
                 "--blocking", "true",
                 "--enabled", "true",
                 "--branch", "main",
@@ -581,7 +587,7 @@ _tasks:
         token = f"repoV2/{project_id}/{repo_id}/refs/heads/6d00610069006e00"
         subprocess.run(
             [
-                "az", "devops", "security", "permission", "update",
+                AZ, "devops", "security", "permission", "update",
                 "--namespace-id", "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87",  # Git Repositories
                 "--subject", descriptor,
                 "--token", token,


### PR DESCRIPTION
Same WinError 2 gap as the integration test scripts: az is an az.cmd batch wrapper on Windows, and subprocess with shell=False (the default here) can't find it from the bare name alone.