### PR TITLE
fix: make Renovate see .jinja-suffixed template workflow files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
   },
   "github-actions": {
     "managerFilePatterns": [
-      "/(^|/)(?:{%.*%})?\\.github(?:{%.*%})?/workflows/.+\\.ya?ml(?:{%.*%})?$/"
+      "/(^|/)(?:{%.*%})?\\.github(?:{%.*%})?/workflows/.+\\.ya?ml(?:{%.*%})?(?:\\.jinja)?$/"
     ]
   },
   "packageRules": [

--- a/template/{% if using_github %}renovate.json{% endif %}.jinja
+++ b/template/{% if using_github %}renovate.json{% endif %}.jinja
@@ -32,7 +32,7 @@
   },
   "github-actions": {
     "managerFilePatterns": [
-      {% raw %}"/(^|/)(?:{%.*%})?\\.github(?:{%.*%})?/workflows/.+\\.ya?ml(?:{%.*%})?$/"{% endraw %}
+      {% raw %}"/(^|/)(?:{%.*%})?\\.github(?:{%.*%})?/workflows/.+\\.ya?ml(?:{%.*%})?(?:\\.jinja)?$/"{% endraw %}
     ]
   },
   {%- endif %}


### PR DESCRIPTION
Mirrors the (?:\.jinja)? suffix already present in the azure-pipelines and devcontainer manager patterns. Without it, Renovate's github-actions manager silently skipped test-pr_validation.yml.jinja -- the one workflow using the .jinja-extension trick instead of {% if %}...{% endif %} around the filename -- so its actions/checkout pin was invisible to Renovate.