### PR TITLE
docs: add AGENTS.md/CLAUDE.md, in the repo root and the template output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,94 @@
+# Notes for AI Agents
+
+## Git workflow
+
+- Commit message style: `type: summary` as the first line (Conventional
+  Commits, enforced by `.config/committed.toml` -- keep the subject at or
+  under 72 characters). A short body paragraph explaining non-obvious
+  rationale is fine when it adds real context; don't pad a trivial change with
+  one just to have one.
+
+## Dogfooding architecture
+
+This repo is both a Copier template (source of truth under `template/`) and,
+via dogfooding, a rendered instance of that same template
+(`project_type: Template` in `.config/copier-answers.yml`). Root-level files
+like `mise.toml`, `README.md`, `docs/`, and `.github/workflows/` are
+**rendered output**, not hand-maintained -- they lag behind `template/` until
+an explicit `copier update` (or a new release) re-renders them. **Never
+hand-edit a root-level dogfooded file; edit the matching `template/` source
+instead.**
+
+Two exceptions:
+
+- **Root `copier.yml`** must be kept in sync **immediately**, in the same
+  turn as any edit to `template/{% if is_template %}copier.yml{% endif %}.jinja`'s
+  raw-block body. Copier reads root `copier.yml` directly (not from inside
+  `template/`) when this repo is used as a Copier source, so a stale root
+  copy breaks real usage, not just documentation. Safe method: render just
+  `copier.yml` from the updated template against this repo's own recorded
+  answers, diff against the current root file to confirm the delta is exactly
+  the intended edit, then replace it wholesale.
+- Occasionally another root file is operationally load-bearing enough that
+  staleness causes an active problem right now (not just "missing a new
+  feature until the next update") -- e.g. `renovate.json`, which Renovate
+  reads directly on its own schedule regardless of `copier update`. Treat
+  syncing those as a deliberate, flagged exception, not the default.
+
+When validating template changes (e.g. testing uncommitted edits), don't copy
+this repo's root as a Copier source -- either render fresh from `template/` or
+run a real `copier update --vcs-ref=HEAD` first, since the root will be stale.
+
+If `copier update`/`copier recopy` ever deadlocks trying to render an old
+baseline tag (e.g. a removed extension module the old tag still references),
+`copier copy --overwrite --data-file <answers-file-with-underscore-keys-stripped>
+--vcs-ref=HEAD gh:<owner>/<repo> .` is the escape hatch -- but it has no
+"preserve unless template changed" diffing, so treat its output as a rough
+draft and diff every changed file against the pre-copy `HEAD` before staging.
+
+## Render-validation test suite
+
+Location: `template/{% if is_template %}tests{% endif %}/`, not the root
+`tests/` (a dogfooded, stale copy -- see above). **Always run the suite
+against the template source directly, never the root copy, when validating a
+change to the test suite itself:**
+
+```sh
+mise x -- pytest "template/{% if is_template %}tests{% endif %}/"
+```
+
+Running `pytest tests/` from the repo root collects the stale root copy --
+`_assemble_source`'s render-based checks still validate current `template/`
+*content* correctly (it always copies fresh from `template/` regardless of
+which copy of `conftest.py` is executing), but a newly added/edited *test
+function* only exists in the template source and silently never runs from
+root.
+
+Files: `conftest.py` (shared fixtures), `test_render.py` (structural
+validation across `answer_matrix.py`'s `ANSWER_MATRIX`, including an
+update-from-last-tag path), `test_content.py` (config/content consistency,
+e.g. nav completeness, hook-tool availability), `test_validators.py` (asserts
+`copier.yml.jinja`'s `validator:` blocks actually reject what they claim to,
+via `INVALID_ANSWER_MATRIX`), `test_answer_matrix_coverage.py` (audits
+`answer_matrix.py` itself against the real question set). **Update
+`answer_matrix.py` whenever a Copier question is added, removed, or renamed,
+or a new `validator:` constraint is added.**
+
+## Renovate `schedule` cron syntax is not standard cron
+
+Renovate's `schedule` option (see `renovate.json` / `template/{% if using_github %}renovate.json{% endif %}.jinja`)
+looks like 5-field cron but isn't interpreted the same way:
+
+- The minutes field **must** be `*` -- Renovate doesn't support minute-level
+  granularity, and a schedule that restricts it is invalid.
+- A cron schedule defines an allowed **time window**, not an exact trigger
+  instant -- Renovate itself runs on its own polling cadence (external to
+  this repo) and only acts during the window the schedule describes.
+
+So `"* 0 1 * *"` is the *correct* idiomatic form for "once a month, on the
+1st, during hour 0" -- it is not a bug, even though it looks like a broken
+"every minute" cron at a glance. Do not change it to `"0 0 1 * *"` (a
+standard-cron-style fix) -- that's invalid for Renovate specifically, since it
+constrains the minutes field.
+
+Reference: <https://docs.renovatebot.com/key-concepts/scheduling/>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- rumdl-disable MD041 -->
+@AGENTS.md

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -1,0 +1,119 @@
+# Notes for AI Agents
+
+## Git workflow
+
+- Default to a feature branch + PR for any change -- do not commit directly to
+  `main` unless explicitly re-authorized for a specific batch.
+- When working through more than one independent fix/feature, commit **one
+  logical change at a time**: make the change, verify it for real (render,
+  lint, test -- not assumption), stage it, show the diff, propose a commit
+  message, and wait for explicit approval before running `git commit`. Don't
+  bundle unrelated fixes into one commit, even if it's faster -- it's fine to
+  bundle a fix with file(s) it's obviously coupled to (e.g. a new file plus
+  the config change needed to lint it).
+- Proposing a commit message inside a longer summary is **not** approval to
+  commit. Print the full proposed message as its own block (e.g. a code
+  fence), then wait for a distinct yes -- don't infer approval from the
+  absence of an objection to a summary that already contains the message.
+- Push the branch immediately after every `git commit` -- no separate
+  confirmation needed for the push itself. Opening the PR is still a separate
+  step, done only when asked (the usual pattern is the human opens/merges the
+  PR themselves).
+- After a commit+push, if there's no more queued work on that branch, switch
+  back to `main` (and `git pull`) rather than leaving the session sitting on a
+  finished feature branch.
+- Commit message style: `type: summary` as the first line (Conventional
+  Commits, enforced by `.config/committed.toml` -- keep the subject at or
+  under 72 characters). A short body paragraph explaining non-obvious
+  rationale is fine when it adds real context; don't pad a trivial change with
+  one just to have one.
+{%- if is_template %}
+
+## Dogfooding architecture
+
+This is a Copier template (source of truth under `template/`). If this
+project's own `.config/copier-answers.yml` `_src_path` is ever pointed back at
+itself rather than at its parent template -- i.e. it "dogfoods" itself,
+generating its own root from its own `template/` -- then it becomes both the
+template and a rendered instance of that same template, and the following
+applies: root-level files like `mise.toml`, `README.md`, `docs/`, and
+`.github/workflows/` are **rendered output**, not hand-maintained -- they lag
+behind `template/` until an explicit `copier update` (or a new release)
+re-renders them. **Never hand-edit a root-level dogfooded file; edit the
+matching `template/` source instead.**
+
+Two exceptions:
+
+- **Root `copier.yml`** must be kept in sync **immediately**, in the same
+  turn as any edit to {% raw %}`template/{% if is_template %}copier.yml{% endif %}.jinja`{% endraw %}'s
+  raw-block body. Copier reads root `copier.yml` directly (not from inside
+  `template/`) when this project is used as a Copier source, so a stale root
+  copy breaks real usage, not just documentation. Safe method: render just
+  `copier.yml` from the updated template against this project's own recorded
+  answers, diff against the current root file to confirm the delta is exactly
+  the intended edit, then replace it wholesale.
+- Occasionally another root file is operationally load-bearing enough that
+  staleness causes an active problem right now (not just "missing a new
+  feature until the next update") -- e.g. `renovate.json`, which Renovate
+  reads directly on its own schedule regardless of `copier update`. Treat
+  syncing those as a deliberate, flagged exception, not the default.
+
+When validating template changes (e.g. testing uncommitted edits), don't copy
+this project's root as a Copier source -- either render fresh from `template/`
+or run a real `copier update --vcs-ref=HEAD` first, since the root will be
+stale.
+
+If `copier update`/`copier recopy` ever deadlocks trying to render an old
+baseline tag (e.g. a removed extension module the old tag still references),
+`copier copy --overwrite --data-file <answers-file-with-underscore-keys-stripped>
+--vcs-ref=HEAD gh:<owner>/<repo> .` is the escape hatch -- but it has no
+"preserve unless template changed" diffing, so treat its output as a rough
+draft and diff every changed file against the pre-copy `HEAD` before staging.
+
+## Render-validation test suite
+
+Location: {% raw %}`template/{% if is_template %}tests{% endif %}/`{% endraw %}.
+**If this project also dogfoods itself (see above), always run the suite
+against the template source directly, never a root copy, when validating a
+change to the test suite itself:**
+
+```sh
+{% raw %}mise x -- pytest "template/{% if is_template %}tests{% endif %}/"{% endraw %}
+```
+
+Running `pytest tests/` from the project root would collect a stale root
+copy instead -- render-based checks still validate current `template/`
+*content* correctly (they copy fresh from `template/` regardless of which
+copy of `conftest.py` is executing), but a newly added/edited *test function*
+only exists in the template source and would silently never run from root.
+
+Files: `conftest.py` (shared fixtures), `test_render.py` (structural
+validation across `answer_matrix.py`'s `ANSWER_MATRIX`, including an
+update-from-last-tag path), `test_content.py` (config/content consistency,
+e.g. nav completeness, hook-tool availability), `test_validators.py` (asserts
+`copier.yml.jinja`'s `validator:` blocks actually reject what they claim to,
+via `INVALID_ANSWER_MATRIX`), `test_answer_matrix_coverage.py` (audits
+`answer_matrix.py` itself against the real question set). **Update
+`answer_matrix.py` whenever a Copier question is added, removed, or renamed,
+or a new `validator:` constraint is added.**
+{%- endif %}
+
+## Renovate `schedule` cron syntax is not standard cron
+
+Renovate's `schedule` option{% if using_github %} (see `renovate.json`{% if is_template %} / {% raw %}`template/{% if using_github %}renovate.json{% endif %}.jinja`{% endraw %}{% endif %}){% endif %}
+looks like 5-field cron but isn't interpreted the same way -- this applies to
+any platform Renovate runs on, not just GitHub:
+
+- The minutes field **must** be `*` -- Renovate doesn't support minute-level
+  granularity, and a schedule that restricts it is invalid.
+- A cron schedule defines an allowed **time window**, not an exact trigger
+  instant -- Renovate itself runs on its own polling cadence (external to
+  this project) and only acts during the window the schedule describes.
+
+So `"* 0 1 * *"` is the *correct* idiomatic form for "once a month, on the
+1st, during hour 0" -- it is not a bug, even though it looks like a broken
+"every minute" cron at a glance. Do not change it to `"0 0 1 * *"` (a
+standard-cron-style fix) -- that's invalid for Renovate specifically, since it
+constrains the minutes field.
+
+Reference: <https://docs.renovatebot.com/key-concepts/scheduling/>

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- rumdl-disable MD041 -->
+@AGENTS.md


### PR DESCRIPTION
Records durable, repo-relevant knowledge in a shared, version-controlled file instead of private per-agent memory: commit message style, the dogfooding architecture (root files are stale rendered output except copier.yml), the render-validation test suite's structure and its run-from-template-not-root gotcha, and Renovate's non-standard cron semantics. CLAUDE.md is a thin `@AGENTS.md` import per Claude Code's documented convention for repos that already use AGENTS.md.

template/AGENTS.md.jinja carries the same content into every generated project, gating the dogfooding/test-suite sections behind is_template. The Renovate cron section stays unconditional (not GitHub-specific knowledge, and AzDO Renovate support may be added later); only its file-path mention is conditional on using_github.