### PR TITLE
fix: group GitHub CLI's two Renovate package names

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -52,6 +52,14 @@
       "groupName": "apprise"
     },
     {
+      "description": "Group cli",
+      "matchPackageNames": [
+        "cli/cli",
+        "aqua:cli/cli"
+      ],
+      "groupName": "cli"
+    },
+    {
       "description": "Group commitizen",
       "matchPackageNames": [
         "commitizen",

--- a/template/{% if using_github %}renovate.json{% endif %}.jinja
+++ b/template/{% if using_github %}renovate.json{% endif %}.jinja
@@ -60,6 +60,14 @@
       "groupName": "apprise"
     },
     {
+      "description": "Group cli",
+      "matchPackageNames": [
+        "cli/cli",
+        "aqua:cli/cli"
+      ],
+      "groupName": "cli"
+    },
+    {
       "description": "Group commitizen",
       "matchPackageNames": [
         "commitizen",


### PR DESCRIPTION
`"aqua:cli/cli"` and the renovate-comment-derived `cli/cli` were tracked as separate packages, producing duplicate dashboard PRs for the same tool. Groups them the same way as the other aqua-backed tools (typos, prek, ryl, tombi).