### PR TITLE
feat: add a scheduled Renovate pipeline for Azure DevOps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ or a new `validator:` constraint is added.**
 
 ## Renovate `schedule` cron syntax is not standard cron
 
-Renovate's `schedule` option (see `renovate.json` / `template/{% if using_github %}renovate.json{% endif %}.jinja`)
+Renovate's `schedule` option (see `renovate.json` / `template/renovate.json.jinja`)
 looks like 5-field cron but isn't interpreted the same way:
 
 - The minutes field **must** be `*` -- Renovate doesn't support minute-level

--- a/copier.yml
+++ b/copier.yml
@@ -478,6 +478,19 @@ _tasks:
         true
       {%- endif %}
 
+  # Creates Azure Pipeline for renovate
+  - command: >-
+      az pipelines create
+      --name "[{{ repo_name }}] renovate"
+      --repository {{ repo_name }}
+      --repository-type tfsgit
+      --branch main
+      --yml-path .azurepipelines/renovate.yml
+      --skip-first-run true
+      --org https://dev.azure.com/{{ azdo_org }}/
+      --project "{{ azdo_project }}"
+    when: *when_copy_set_repo_settings_azdo
+
   # Creates Azure Pipeline for docs
   - command: >-
       az pipelines create

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -100,9 +100,9 @@ or a new `validator:` constraint is added.**
 
 ## Renovate `schedule` cron syntax is not standard cron
 
-Renovate's `schedule` option{% if using_github %} (see `renovate.json`{% if is_template %} / {% raw %}`template/{% if using_github %}renovate.json{% endif %}.jinja`{% endraw %}{% endif %}){% endif %}
+Renovate's `schedule` option (see `renovate.json`{% if is_template %} / `template/renovate.json.jinja`{% endif %})
 looks like 5-field cron but isn't interpreted the same way -- this applies to
-any platform Renovate runs on, not just GitHub:
+any platform Renovate runs on:
 
 - The minutes field **must** be `*` -- Renovate doesn't support minute-level
   granularity, and a schedule that restricts it is invalid.

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": {% if using_github %}true{% else %}false{% endif %},
+  "dependencyDashboard": true,
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests"
@@ -115,6 +115,16 @@
       ],
       "groupName": "prek"
     },
+    {%- if using_azdo %}
+    {
+      "description": "Group renovate",
+      "matchPackageNames": [
+        "renovate",
+        "npm:renovate"
+      ],
+      "groupName": "renovate"
+    },
+    {%- endif %}
     {
       "description": "Group ruff",
       "matchPackageNames": [

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -491,6 +491,19 @@ _tasks:
         true
       {%- endif %}
 
+  # Creates Azure Pipeline for renovate
+  - command: >-
+      az pipelines create
+      --name "[{{ repo_name }}] renovate"
+      --repository {{ repo_name }}
+      --repository-type tfsgit
+      --branch main
+      --yml-path .azurepipelines/renovate.yml
+      --skip-first-run true
+      --org https://dev.azure.com/{{ azdo_org }}/
+      --project "{{ azdo_project }}"
+    when: *when_copy_set_repo_settings_azdo
+
   # Creates Azure Pipeline for docs
   - command: >-
       az pipelines create

--- a/template/{% if is_template %}docs{% endif %}/platform_notes/azure_devops.md
+++ b/template/{% if is_template %}docs{% endif %}/platform_notes/azure_devops.md
@@ -6,9 +6,16 @@ Support for Azure DevOps is provided on a best-effort basis and has some limitat
   - It is assumed that if you are using Azure DevOps, it is due to organizational requirements.
 - GitHub-specific features not implemented
   - Custom Issue tags
-  - Renovate
 - Branch protection policies not set
   - It is assumed that your organization will be enforcing this at the project level
 - `zensical_target` is always `docs_site Directory in Repo`
   - `GitHub Pages` isn't offered, so Azure DevOps projects never get the release-versioned docs
     site that target provides — see [Getting Started](../index.md#documentation)
+- Renovate needs a one-time manual permission grant
+  - Unlike GitHub (which uses the Renovate GitHub App), Renovate runs here as a self-hosted
+    scheduled pipeline (`.azurepipelines/renovate.yml`), authenticated via the pipeline's own
+    `$(System.AccessToken)` rather than a stored secret. For it to push branches and open PRs,
+    grant the **Project Collection Build Service** account **Contribute**, **Create branch**,
+    and **Contribute to pull requests** on this repo (Project Settings > Repositories > this
+    repo > Security) -- this is normally a one-time, org-wide grant, not something you need to
+    repeat per repo.

--- a/template/{% if is_template %}docs{% endif %}/token_permissions.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/token_permissions.md.jinja
@@ -9,13 +9,13 @@ entered via that platform's own CLI prompt (`gh secret set` / `az pipelines vari
 masked as you type and never passed as a command-line argument. It's opt-in and safe to re-run
 any time, e.g. to rotate a token.
 
-## Update Notifications
+## Notifications
 
-Both platforms' Copier update-check job needs a secret/variable called **APPRISE_URL**. Unlike the
-tokens below, it isn't a scope to grant -- it's an [Apprise](https://github.com/caronc/apprise)
-notification URL pointing at wherever you want update notifications sent (email, Slack, Discord,
-ntfy, Pushover, and 80+ others -- see Apprise's own docs for the URL format for your service of
-choice).
+Both platforms' Copier update-check job{% if using_azdo %} and the Azure DevOps Renovate pipeline
+need{% else %} needs{% endif %} a secret/variable called **APPRISE_URL**. Unlike the tokens below, it isn't a scope to grant -- it's
+an [Apprise](https://github.com/caronc/apprise) notification URL pointing at wherever you want
+these notifications sent (email, Slack, Discord, ntfy, Pushover, and 80+ others -- see Apprise's
+own docs for the URL format for your service of choice).
 {%- if using_github %}
 
 ## GitHub

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/renovate.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/renovate.yml.jinja
@@ -1,0 +1,87 @@
+name: $(BuildId)
+
+trigger:
+  branches:
+    exclude:
+      - "*"
+
+schedules:
+  # Matches renovate.json's own "schedule": ["* 0 1 * *"] window (once a month, day 1,
+  # hour 0 UTC) -- unlike Renovate's schedule syntax, Azure Pipelines cron is standard
+  # cron with real minute granularity, so this fires once, directly in that window,
+  # rather than needing to poll daily.
+  - cron: 0 0 1 * *
+    displayName: Run Renovate Monthly, Matching renovate.json's Schedule
+    branches:
+      include:
+        - main
+
+variables:
+  CI: true
+  MISE_ENV: ci,azdo
+
+pool:
+  vmImage: ubuntu-latest
+
+stages:
+  - stage: renovate
+    displayName: Renovate
+    jobs:
+      - job: renovate
+        timeoutInMinutes: 60
+        displayName: Renovate
+        steps:
+          - pwsh: |
+              $Secrets = @("APPRISE_URL")
+              $MissingSecret = $False
+              foreach ($Secret in $Secrets) {
+                if (!([Environment]::GetEnvironmentVariable($Secret)) -or ([Environment]::GetEnvironmentVariable($Secret) -eq "`$($Secret)")) {
+                  Write-Host -Object "[error]Required Pipeline variable '$Secret' is not set! Please add it in Pipelines settings."
+                  $MissingSecret = $True
+                }
+              }
+              if ($MissingSecret) {
+                throw "Erroring as one or more required secrets are missing!"
+              }
+            env:
+              APPRISE_URL: $(APPRISE_URL)
+            displayName: Validate Secrets Exist
+          - checkout: self
+            fetchDepth: 0
+          - bash: |
+              curl https://mise.run | sh
+              echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
+              echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
+            displayName: Install Mise
+          - bash: mise install
+            displayName: Run 'mise install'
+          - bash: mise x -- renovate "{{ azdo_project }}/{{ repo_name }}"
+            env:
+              RENOVATE_PLATFORM: azure
+              RENOVATE_ENDPOINT: $(System.CollectionUri)
+              RENOVATE_TOKEN: $(System.AccessToken)
+              RENOVATE_CONFIG_FILE: $(Build.SourcesDirectory)/renovate.json
+              RENOVATE_AUTODISCOVER: "false"
+              RENOVATE_REPORT_TYPE: file
+              RENOVATE_REPORT_PATH: $(Build.SourcesDirectory)/renovate-report.json
+            displayName: Run Renovate
+          - pwsh: |
+              $Report = Get-Content -Raw -Path $env:REPORT_PATH | ConvertFrom-Json
+              $CreatedPrs = @()
+              foreach ($RepoName in $Report.repositories.PSObject.Properties.Name) {
+                foreach ($Branch in $Report.repositories.$RepoName.branches) {
+                  if ($Branch.result -eq "pr-created") {
+                    $CreatedPrs += $Branch
+                  }
+                }
+              }
+              if ($CreatedPrs.Count -gt 0) {
+                $Titles = ($CreatedPrs | ForEach-Object { $_.prTitle }) -join "<br>"
+                apprise -i html -t "[$env:BUILD_REPOSITORY_NAME] Renovate Opened $($CreatedPrs.Count) PR(s)" -b "Renovate opened the following PR(s):<br><br>$Titles" $env:APPRISE_URL
+              } else {
+                Write-Host -Object "No new PRs opened by Renovate this run."
+              }
+            env:
+              REPORT_PATH: $(Build.SourcesDirectory)/renovate-report.json
+              APPRISE_URL: $(APPRISE_URL)
+            displayName: Notify if Renovate Opened PRs

--- a/template/{% if using_azdo %}mise.azdo.toml{% endif %}.jinja
+++ b/template/{% if using_azdo %}mise.azdo.toml{% endif %}.jinja
@@ -1,0 +1,8 @@
+[tools]
+# Used by the Renovate pipeline (.azurepipelines/renovate.yml.jinja) -- isolated from
+# the base mise.toml/mise.ci.toml since no other pipeline needs Node.js or Renovate
+# itself.
+{#- renovate: datasource=node-version depName=node versioning=node #}
+node = "24.19.0"
+{#- renovate: datasource=npm depName=renovate #}
+"npm:renovate" = "44.39.3"


### PR DESCRIPTION
Renovate has no hosted app for Azure DevOps (unlike the GitHub App this template already relies on), so this runs it as a self-hosted pipeline authenticated via the pipeline's own $(System.AccessToken) -- no manual PAT needed, but the Project Collection Build Service account needs a one-time manual grant of Contribute/Create branch/Contribute-to-PRs on the repo, documented in platform_notes/azure_devops.md.

renovate.json is no longer GitHub-only (its filename no longer needs a conditional -- GitHub and Azure DevOps are the only two platforms, so the old `using_github` gate was always true anyway). The pipeline's own cron mirrors renovate.json's schedule window, autodiscover is explicitly disabled as a defensive scope guard, and it reports on PRs it opened via reportType=file, notifying APPRISE_URL when any were created.

Renovate itself runs as a version-pinned mise npm tool in a new mise.azdo.toml, isolated from other pipelines since only this one needs Node.js.