### PR TITLE
fix: make Renovate see conditionally-named mise.*.toml files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -182,7 +182,7 @@
       "description": "Manager for simple mise tools",
       "customType": "regex",
       "managerFilePatterns": [
-        "/mise\\..*toml\\.jinja/"
+        "/mise\\..*toml(?:{%.*%})?\\.jinja/"
       ],
       "matchStrings": [
         "{#[-]? renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s*#}\\s+[A-Za-z0-9_\\-\"':/]+\\s?=\\s?[\"'](?<currentValue>[^\"']*)[\"'].*"
@@ -193,7 +193,7 @@
       "description": "Manager for pipx git-sourced tools",
       "customType": "regex",
       "managerFilePatterns": [
-        "/(^|/)mise(\\.\\w+)*\\.toml(\\.jinja)?$/"
+        "/(^|/)(?:{%.*%})?mise(\\.\\w+)*\\.toml(?:{%.*%})?(\\.jinja)?$/"
       ],
       "matchStrings": [
         "\\[tools\\.\"pipx:git\\+https://github\\.com/(?<packageName>[^/]+/[^\"]+)\\.git\"\\]\\s+version = \"(?<currentValue>[^+\"]*)"
@@ -206,7 +206,7 @@
       "customType": "regex",
       "datasourceTemplate": "pypi",
       "managerFilePatterns": [
-        "/mise\\..*toml\\.jinja/"
+        "/mise\\..*toml(?:{%.*%})?\\.jinja/"
       ],
       "matchStrings": [
         "\\[tools\\.\"?pipx:(?<depName>[A-Za-z0-9_.-]+)\"?\\]\\sversion = \"(?<currentValue>[^\\s]*)\""

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -202,7 +202,7 @@
       "description": "Manager for simple mise tools",
       "customType": "regex",
       "managerFilePatterns": [
-        "/mise\\..*toml\\.jinja/"
+        {% raw %}"/mise\\..*toml(?:{%.*%})?\\.jinja/"{% endraw %}
       ],
       "matchStrings": [
         {% raw %}"{#[-]? renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s*#}\\s+[A-Za-z0-9_\\-\"':/]+\\s?=\\s?[\"'](?<currentValue>[^\"']*)[\"'].*"{% endraw %}
@@ -213,7 +213,7 @@
       "description": "Manager for pipx git-sourced tools",
       "customType": "regex",
       "managerFilePatterns": [
-        "/(^|/)mise(\\.\\w+)*\\.toml(\\.jinja)?$/"
+        {% raw %}"/(^|/)(?:{%.*%})?mise(\\.\\w+)*\\.toml(?:{%.*%})?(\\.jinja)?$/"{% endraw %}
       ],
       "matchStrings": [
         "\\[tools\\.\"pipx:git\\+https://github\\.com/(?<packageName>[^/]+/[^\"]+)\\.git\"\\]\\s+version = \"(?<currentValue>[^+\"]*)"
@@ -226,7 +226,7 @@
       "customType": "regex",
       "datasourceTemplate": "pypi",
       "managerFilePatterns": [
-        "/mise\\..*toml\\.jinja/"
+        {% raw %}"/mise\\..*toml(?:{%.*%})?\\.jinja/"{% endraw %}
       ],
       "matchStrings": [
         "\\[tools\\.\"?pipx:(?<depName>[A-Za-z0-9_.-]+)\"?\\]\\sversion = \"(?<currentValue>[^\\s]*)\""


### PR DESCRIPTION
The three custom mise-tool managers (renovate-comment parsing, pipx git-sourced tools, pipx options) all missed template/{% if using_azdo %}mise.azdo.toml{% endif %}.jinja -- their patterns required "toml" adjacent to ".jinja"/end-of-string, but a conditionally-wrapped filename has "{% endif %}" injected in between. Adds the same (?:{%.*%})? optional group already used for the github-actions/azure-pipelines managers. Confirmed against the actual rendered regex strings, not just by inspection -- all three now match the new file plus the two existing unconditional mise.toml.jinja/mise.ci.toml.jinja files.