### PR TITLE
fix: wait for PR validation to pass before auto-merging release/docs PRs

### DIFF
--- a/template/mise.toml.jinja
+++ b/template/mise.toml.jinja
@@ -46,6 +46,8 @@ run = [
 {%- endif %}
 {%- elif using_azdo %}
   "az pipelines variable create --name APPRISE_URL --pipeline-name \"[{{ repo_name }}] copier-update-check\" --secret true --allow-override true --org https://dev.azure.com/{{ azdo_org }}/ --project \"{{ azdo_project }}\"",
+  "az pipelines variable create --name APPRISE_URL --pipeline-name \"[{{ repo_name }}] release\" --secret true --allow-override true --org https://dev.azure.com/{{ azdo_org }}/ --project \"{{ azdo_project }}\"",
+  "az pipelines variable create --name APPRISE_URL --pipeline-name \"[{{ repo_name }}] docs\" --secret true --allow-override true --org https://dev.azure.com/{{ azdo_org }}/ --project \"{{ azdo_project }}\"",
 {%- if is_template and integration_test_scheduled %}
   "az pipelines variable create --name AZURE_DEVOPS_EXT_PAT --pipeline-name \"[{{ repo_name }}] integration_test\" --secret true --allow-override true --org https://dev.azure.com/{{ azdo_org }}/ --project \"{{ azdo_project }}\"",
 {%- endif %}

--- a/template/{% if is_template %}docs{% endif %}/token_permissions.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/token_permissions.md.jinja
@@ -11,8 +11,9 @@ any time, e.g. to rotate a token.
 
 ## Notifications
 
-Both platforms' Copier update-check job{% if using_azdo %} and the Azure DevOps Renovate pipeline
-need{% else %} needs{% endif %} a secret/variable called **APPRISE_URL**. Unlike the tokens below, it isn't a scope to grant -- it's
+Both platforms' Copier update-check job{% if using_azdo %}, the Azure DevOps Renovate pipeline, and
+the Azure DevOps release/docs pipelines (which notify on both successful auto-merge and on PR
+validation failing to pass, since those pipelines merge without a human in the loop) need{% else %} needs{% endif %} a secret/variable called **APPRISE_URL**. Unlike the tokens below, it isn't a scope to grant -- it's
 an [Apprise](https://github.com/caronc/apprise) notification URL pointing at wherever you want
 these notifications sent (email, Slack, Discord, ntfy, Pushover, and 80+ others -- see Apprise's
 own docs for the URL format for your service of choice).

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/docs.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/docs.yml.jinja
@@ -24,6 +24,21 @@ stages:
         timeoutInMinutes: 60
         displayName: Build Zensical
         steps:
+          - pwsh: |
+              $Secrets = @("APPRISE_URL")
+              $MissingSecret = $False
+              foreach ($Secret in $Secrets) {
+                if (!([Environment]::GetEnvironmentVariable($Secret)) -or ([Environment]::GetEnvironmentVariable($Secret) -eq "`$($Secret)")) {
+                  Write-Host -Object "[error]Required Pipeline variable '$Secret' is not set! Please add it in Pipelines settings."
+                  $MissingSecret = $True
+                }
+              }
+              if ($MissingSecret) {
+                throw "Erroring as one or more required secrets are missing!"
+              }
+            env:
+              APPRISE_URL: $(APPRISE_URL)
+            displayName: Validate Secrets Exist
           - checkout: self
             fetchDepth: 0
             persistCredentials: true
@@ -87,8 +102,6 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           - pwsh: |
-              $MergeCommitMessage = "$(PR_TITLE)"
-
               $ProjectBaseUri = "$(System.CollectionUri)/$(System.TeamProject)/_apis"
               $BaseSplat = @{
                 ContentType = "application/json"
@@ -119,8 +132,71 @@ stages:
               }
               Write-Host "Approving Pull Request..."
               Invoke-RestMethod @ApproveSplat | Out-Null
+            displayName: Approve Pull Request
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          - pwsh: |
+              # Polls the PR-validation build-validation policy (set up by "az repos policy
+              # build create" in copier.yml.jinja's repo-setup tasks) until it reaches a
+              # terminal state, instead of bypassing it. Unlike GitHub's release-please flow
+              # (which only ever opens/updates a PR for a human to merge), this pipeline
+              # auto-merges its own PR, so it must earn a real pass through the same policy
+              # every other PR on this repo is required to pass, rather than silently
+              # skipping it.
+              $ProjectBaseUri = "$(System.CollectionUri)/$(System.TeamProject)/_apis"
+              $BaseSplat = @{
+                ContentType = "application/json"
+                Headers = @{
+                  Authorization = "Basic $([Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("user:$env:SYSTEM_ACCESSTOKEN")))"
+                }
+              }
 
-              Start-Sleep -Seconds 5
+              $ArtifactID = "vstfs:///CodeReview/CodeReviewId/$(System.TeamProjectId)/$(PULL_REQUEST_ID)"
+              $EvalSplat = $BaseSplat + @{
+                Uri = "$ProjectBaseUri/policy/evaluations?artifactId=$([Uri]::EscapeDataString($ArtifactID))&api-version=7.1-preview.1"
+                Method = "GET"
+              }
+
+              $MaxAttempts = 40
+              $DelaySeconds = 30
+              $Status = "queued"
+              for ($Attempt = 1; $Attempt -le $MaxAttempts; $Attempt++) {
+                $EvalResponse = Invoke-RestMethod @EvalSplat
+                $Evaluations = if ($EvalResponse.PSObject.Properties.Name -contains "value") { $EvalResponse.value } else { $EvalResponse }
+                $BuildEval = $Evaluations | Where-Object { $_.configuration.type.displayName -eq "Build" } | Select-Object -First 1
+
+                if (-not $BuildEval) {
+                  Write-Host "No build-validation policy evaluation found yet (attempt $Attempt/$MaxAttempts)..."
+                } else {
+                  $Status = $BuildEval.status
+                  Write-Host "Build-validation policy status: $Status (attempt $Attempt/$MaxAttempts)"
+                  if ($Status -in @("approved", "rejected", "broken", "notApplicable")) {
+                    break
+                  }
+                }
+
+                Start-Sleep -Seconds $DelaySeconds
+              }
+
+              Write-Host "##vso[task.setvariable variable=PR_VALIDATION_STATUS;]$Status"
+            displayName: Wait for PR Validation Policy
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          - pwsh: |
+              if ("$(PR_VALIDATION_STATUS)" -ne "approved") {
+                apprise -i html -t "[$env:BUILD_REPOSITORY_NAME] Docs PR Needs Manual Attention" -b "PR #$(PULL_REQUEST_ID) ($(PR_TITLE)) did not pass PR validation (status: $(PR_VALIDATION_STATUS)) and was not merged automatically. Please review it manually." $env:APPRISE_URL
+                throw "PR validation did not succeed (status: $(PR_VALIDATION_STATUS)) -- leaving PR #$(PULL_REQUEST_ID) open for manual review."
+              }
+
+              $MergeCommitMessage = "$(PR_TITLE)"
+
+              $ProjectBaseUri = "$(System.CollectionUri)/$(System.TeamProject)/_apis"
+              $BaseSplat = @{
+                ContentType = "application/json"
+                Headers = @{
+                  Authorization = "Basic $([Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("user:$env:SYSTEM_ACCESSTOKEN")))"
+                }
+              }
 
               $MergeSplat = $BaseSplat + @{
                 Uri = "$ProjectBaseUri/git/repositories/$(Build.Repository.Name)/pullrequests/$(PULL_REQUEST_ID)?api-version=7.0"
@@ -131,8 +207,6 @@ stages:
                   }
                   status = "completed"
                   completionOptions = @{
-                    bypassPolicy = $true
-                    bypassReason = "Pipeline Automation"
                     deleteSourceBranch = $true
                     mergeCommitMessage = $MergeCommitMessage
                     mergeStrategy = "squash"
@@ -141,6 +215,9 @@ stages:
               }
               Write-Host "Merging Pull Request..."
               Invoke-RestMethod @MergeSplat | Out-Null
-            displayName: Approve & Merge Pull Request
+
+              apprise -i html -t "[$env:BUILD_REPOSITORY_NAME] Docs PR Merged" -b "PR #$(PULL_REQUEST_ID) ($(PR_TITLE)) passed PR validation and was merged automatically." $env:APPRISE_URL
+            displayName: Merge Pull Request
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              APPRISE_URL: $(APPRISE_URL)

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/release.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/release.yml
@@ -20,6 +20,21 @@ stages:
         timeoutInMinutes: 60
         displayName: Release
         steps:
+          - pwsh: |
+              $Secrets = @("APPRISE_URL")
+              $MissingSecret = $False
+              foreach ($Secret in $Secrets) {
+                if (!([Environment]::GetEnvironmentVariable($Secret)) -or ([Environment]::GetEnvironmentVariable($Secret) -eq "`$($Secret)")) {
+                  Write-Host -Object "[error]Required Pipeline variable '$Secret' is not set! Please add it in Pipelines settings."
+                  $MissingSecret = $True
+                }
+              }
+              if ($MissingSecret) {
+                throw "Erroring as one or more required secrets are missing!"
+              }
+            env:
+              APPRISE_URL: $(APPRISE_URL)
+            displayName: Validate Secrets Exist
           - checkout: self
             fetchDepth: 0
             persistCredentials: true
@@ -84,8 +99,6 @@ stages:
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           - pwsh: |
-              $MergeCommitMessage = "$(PR_TITLE)"
-
               $ProjectBaseUri = "$(System.CollectionUri)/$(System.TeamProject)/_apis"
               $BaseSplat = @{
                 ContentType = "application/json"
@@ -116,8 +129,71 @@ stages:
               }
               Write-Host "Approving Pull Request..."
               Invoke-RestMethod @ApproveSplat | Out-Null
+            displayName: Approve Pull Request
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          - pwsh: |
+              # Polls the PR-validation build-validation policy (set up by "az repos policy
+              # build create" in copier.yml.jinja's repo-setup tasks) until it reaches a
+              # terminal state, instead of bypassing it. Unlike GitHub's release-please flow
+              # (which only ever opens/updates a PR for a human to merge), this pipeline
+              # auto-merges its own PR, so it must earn a real pass through the same policy
+              # every other PR on this repo is required to pass, rather than silently
+              # skipping it.
+              $ProjectBaseUri = "$(System.CollectionUri)/$(System.TeamProject)/_apis"
+              $BaseSplat = @{
+                ContentType = "application/json"
+                Headers = @{
+                  Authorization = "Basic $([Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("user:$env:SYSTEM_ACCESSTOKEN")))"
+                }
+              }
 
-              Start-Sleep -Seconds 5
+              $ArtifactID = "vstfs:///CodeReview/CodeReviewId/$(System.TeamProjectId)/$(PULL_REQUEST_ID)"
+              $EvalSplat = $BaseSplat + @{
+                Uri = "$ProjectBaseUri/policy/evaluations?artifactId=$([Uri]::EscapeDataString($ArtifactID))&api-version=7.1-preview.1"
+                Method = "GET"
+              }
+
+              $MaxAttempts = 40
+              $DelaySeconds = 30
+              $Status = "queued"
+              for ($Attempt = 1; $Attempt -le $MaxAttempts; $Attempt++) {
+                $EvalResponse = Invoke-RestMethod @EvalSplat
+                $Evaluations = if ($EvalResponse.PSObject.Properties.Name -contains "value") { $EvalResponse.value } else { $EvalResponse }
+                $BuildEval = $Evaluations | Where-Object { $_.configuration.type.displayName -eq "Build" } | Select-Object -First 1
+
+                if (-not $BuildEval) {
+                  Write-Host "No build-validation policy evaluation found yet (attempt $Attempt/$MaxAttempts)..."
+                } else {
+                  $Status = $BuildEval.status
+                  Write-Host "Build-validation policy status: $Status (attempt $Attempt/$MaxAttempts)"
+                  if ($Status -in @("approved", "rejected", "broken", "notApplicable")) {
+                    break
+                  }
+                }
+
+                Start-Sleep -Seconds $DelaySeconds
+              }
+
+              Write-Host "##vso[task.setvariable variable=PR_VALIDATION_STATUS;]$Status"
+            displayName: Wait for PR Validation Policy
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          - pwsh: |
+              if ("$(PR_VALIDATION_STATUS)" -ne "approved") {
+                apprise -i html -t "[$env:BUILD_REPOSITORY_NAME] Release PR Needs Manual Attention" -b "PR #$(PULL_REQUEST_ID) ($(PR_TITLE)) did not pass PR validation (status: $(PR_VALIDATION_STATUS)) and was not merged automatically. Please review it manually." $env:APPRISE_URL
+                throw "PR validation did not succeed (status: $(PR_VALIDATION_STATUS)) -- leaving PR #$(PULL_REQUEST_ID) open for manual review."
+              }
+
+              $MergeCommitMessage = "$(PR_TITLE)"
+
+              $ProjectBaseUri = "$(System.CollectionUri)/$(System.TeamProject)/_apis"
+              $BaseSplat = @{
+                ContentType = "application/json"
+                Headers = @{
+                  Authorization = "Basic $([Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("user:$env:SYSTEM_ACCESSTOKEN")))"
+                }
+              }
 
               $MergeSplat = $BaseSplat + @{
                 Uri = "$ProjectBaseUri/git/repositories/$(Build.Repository.Name)/pullrequests/$(PULL_REQUEST_ID)?api-version=7.0"
@@ -128,8 +204,6 @@ stages:
                   }
                   status = "completed"
                   completionOptions = @{
-                    bypassPolicy = $true
-                    bypassReason = "Pipeline Automation"
                     deleteSourceBranch = $true
                     mergeCommitMessage = $MergeCommitMessage
                     mergeStrategy = "squash"
@@ -138,6 +212,9 @@ stages:
               }
               Write-Host "Merging Pull Request..."
               Invoke-RestMethod @MergeSplat | Out-Null
-            displayName: Approve & Merge Pull Request
+
+              apprise -i html -t "[$env:BUILD_REPOSITORY_NAME] Release PR Merged" -b "PR #$(PULL_REQUEST_ID) ($(PR_TITLE)) passed PR validation and was merged automatically." $env:APPRISE_URL
+            displayName: Merge Pull Request
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              APPRISE_URL: $(APPRISE_URL)


### PR DESCRIPTION
The Azure DevOps release and docs pipelines self-approved and merged their own PRs with completionOptions.bypassPolicy = $true, unconditionally skipping the PR-validation build policy every other PR on the repo is required to pass. Poll the policy evaluation via the REST API instead and only merge once it genuinely succeeds, notifying via Apprise on both success and failure/timeout so an unattended merge (or a stuck PR needing manual review) is visible. Provision APPRISE_URL for the release/docs pipelines in provision-secrets, and document the new requirement.