### PR TITLE
fix: pin the mise install script in Azure Pipelines to a known version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -214,6 +214,20 @@
       "versioningTemplate": "pep440"
     },
     {
+      "description": "Manager for the mise install version pin in Azure Pipelines",
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "jdx/mise",
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "managerFilePatterns": [
+        "/(^|/)(?:{%.*%})?\\.azurepipelines(?:{%.*%})?/.+\\.ya?ml(?:{%.*%})?(?:\\.jinja)?$/"
+      ],
+      "matchStrings": [
+        "MISE_VERSION=v(?<currentValue>[^\\s]+)"
+      ],
+      "versioningTemplate": "semver"
+    },
+    {
       "description": "Manager for pipx tool dependencies",
       "customType": "regex",
       "datasourceTemplate": "pypi",

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -233,6 +233,20 @@
       ],
       "versioningTemplate": "pep440"
     },
+    {
+      "description": "Manager for the mise install version pin in Azure Pipelines",
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "jdx/mise",
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "managerFilePatterns": [
+        {% raw %}"/(^|/)(?:{%.*%})?\\.azurepipelines(?:{%.*%})?/.+\\.ya?ml(?:{%.*%})?(?:\\.jinja)?$/"{% endraw %}
+      ],
+      "matchStrings": [
+        "MISE_VERSION=v(?<currentValue>[^\\s]+)"
+      ],
+      "versioningTemplate": "semver"
+    },
     {%- endif %}
     {
       "description": "Manager for pipx tool dependencies",

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/copier-update-check.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/copier-update-check.yml
@@ -46,7 +46,8 @@ stages:
             fetchDepth: 0
             persistCredentials: true
           - bash: |
-              curl https://mise.run | sh
+              # renovate: datasource=github-releases depName=jdx/mise
+              curl https://mise.run | MISE_VERSION=v2026.8.10 MISE_INSTALL_SKIP_IF_EXISTS=1 sh
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
             displayName: Install Mise

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/docs.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/docs.yml.jinja
@@ -32,7 +32,8 @@ stages:
               git config user.name "Azure DevOps"
             displayName: Set Git Config
           - bash: |
-              curl https://mise.run | sh
+              # renovate: datasource=github-releases depName=jdx/mise
+              curl https://mise.run | MISE_VERSION=v2026.8.10 MISE_INSTALL_SKIP_IF_EXISTS=1 sh
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
             displayName: Install Mise

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
@@ -27,7 +27,8 @@ stages:
           - checkout: self
             fetchDepth: 0
           - bash: |
-              curl https://mise.run | sh
+              # renovate: datasource=github-releases depName=jdx/mise
+              curl https://mise.run | MISE_VERSION=v2026.8.10 MISE_INSTALL_SKIP_IF_EXISTS=1 sh
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
             displayName: Install Mise

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/release.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/release.yml
@@ -28,7 +28,8 @@ stages:
               git config user.name "Azure DevOps"
             displayName: Set Git Config
           - bash: |
-              curl https://mise.run | sh
+              # renovate: datasource=github-releases depName=jdx/mise
+              curl https://mise.run | MISE_VERSION=v2026.8.10 MISE_INSTALL_SKIP_IF_EXISTS=1 sh
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
             displayName: Install Mise

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/renovate.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/renovate.yml.jinja
@@ -49,7 +49,8 @@ stages:
           - checkout: self
             fetchDepth: 0
           - bash: |
-              curl https://mise.run | sh
+              # renovate: datasource=github-releases depName=jdx/mise
+              curl https://mise.run | MISE_VERSION=v2026.8.10 MISE_INSTALL_SKIP_IF_EXISTS=1 sh
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
             displayName: Install Mise

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/{% if is_template and integration_test_scheduled %}integration_test.yml{% endif %}
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/{% if is_template and integration_test_scheduled %}integration_test.yml{% endif %}
@@ -44,7 +44,8 @@ stages:
           - checkout: self
             fetchDepth: 0
           - bash: |
-              curl https://mise.run | sh
+              # renovate: datasource=github-releases depName=jdx/mise
+              curl https://mise.run | MISE_VERSION=v2026.8.10 MISE_INSTALL_SKIP_IF_EXISTS=1 sh
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
             displayName: Install Mise


### PR DESCRIPTION
curl https://mise.run | sh installed whatever the latest mise release happened to be on each run, unlike every other tool in this repo (GitHub Actions are SHA-pinned; mise-managed tools are all version-pinned). Pin to v2026.8.10 and skip reinstalling if that version is already present, and add a Renovate customManager so the pin gets bumped going forward like everything else.