### PR TITLE
fix: provision APPRISE_URL for the Azure DevOps Renovate pipeline

### DIFF
--- a/template/mise.toml.jinja
+++ b/template/mise.toml.jinja
@@ -48,6 +48,7 @@ run = [
   "az pipelines variable create --name APPRISE_URL --pipeline-name \"[{{ repo_name }}] copier-update-check\" --secret true --allow-override true --org https://dev.azure.com/{{ azdo_org }}/ --project \"{{ azdo_project }}\"",
   "az pipelines variable create --name APPRISE_URL --pipeline-name \"[{{ repo_name }}] release\" --secret true --allow-override true --org https://dev.azure.com/{{ azdo_org }}/ --project \"{{ azdo_project }}\"",
   "az pipelines variable create --name APPRISE_URL --pipeline-name \"[{{ repo_name }}] docs\" --secret true --allow-override true --org https://dev.azure.com/{{ azdo_org }}/ --project \"{{ azdo_project }}\"",
+  "az pipelines variable create --name APPRISE_URL --pipeline-name \"[{{ repo_name }}] renovate\" --secret true --allow-override true --org https://dev.azure.com/{{ azdo_org }}/ --project \"{{ azdo_project }}\"",
 {%- if is_template and integration_test_scheduled %}
   "az pipelines variable create --name AZURE_DEVOPS_EXT_PAT --pipeline-name \"[{{ repo_name }}] integration_test\" --secret true --allow-override true --org https://dev.azure.com/{{ azdo_org }}/ --project \"{{ azdo_project }}\"",
 {%- endif %}


### PR DESCRIPTION
renovate.yml.jinja's own "Validate Secrets Exist" step already requires APPRISE_URL, but provision-secrets only ever set it on the copier-update-check pipeline (and, since the previous fix, release/docs) -- never renovate itself, since AzDO pipeline variables set via --pipeline-name are scoped per pipeline, not shared. mise run provision-secrets following the documented setup flow left the Renovate pipeline failing out of the box.