### PR TITLE
fix: correct the after-copy message's repo-setup guidance

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -639,8 +639,12 @@ _tasks:
 
 ## Start Messages
 _message_after_copy: |-
-  {%- if using_github and not should_set_repo_settings -%}
+  {%- if using_github -%}
     Repo settings (labels, merge options, branch protection) are not being applied automatically. See the 'Manual Repo Settings' page in documentation for how to replicate them by hand, or install the Settings GitHub App (https://github.com/apps/settings) and it will pick up the already-generated .github/settings.yml on its own.
+
+  {% endif -%}
+  {%- if using_azdo and not should_set_repo_settings -%}
+    Azure Pipelines and the PR-validation build policy were not created automatically since repo setup was skipped. See the 'Manual Repo Settings' page in documentation for how to set these up by hand.
 
   {% endif -%}
   {%- if using_github -%}

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -652,8 +652,12 @@ _tasks:
 
 ## Start Messages
 _message_after_copy: |-
-  {%- if using_github and not should_set_repo_settings -%}
+  {%- if using_github -%}
     Repo settings (labels, merge options, branch protection) are not being applied automatically. See the 'Manual Repo Settings' page in documentation for how to replicate them by hand, or install the Settings GitHub App (https://github.com/apps/settings) and it will pick up the already-generated .github/settings.yml on its own.
+
+  {% endif -%}
+  {%- if using_azdo and not should_set_repo_settings -%}
+    Azure Pipelines and the PR-validation build policy were not created automatically since repo setup was skipped. See the 'Manual Repo Settings' page in documentation for how to set these up by hand.
 
   {% endif -%}
   {%- if using_github -%}


### PR DESCRIPTION
The GitHub settings-app warning only showed when repo_setup_actions was None, implying it doesn't apply otherwise -- but nothing in _tasks ever applies GitHub labels/merge-options/branch-protection directly, it's always dependent on the Settings GitHub App regardless of that choice. Show it unconditionally for using_github, and add the equivalent warning for using_azdo (whose pipelines/PR-validation policy really are skipped when repo_setup_actions is None), which previously got no guidance at all.