### PR TITLE
docs: add Azure DevOps guidance to Manual Repo Settings

### DIFF
--- a/template/{% if is_template %}docs{% endif %}/manual_repo_settings.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/manual_repo_settings.md.jinja
@@ -1,4 +1,5 @@
 # Manual Repo Settings
+{%- if using_github %}
 
 When you use the [Settings GitHub App](https://github.com/apps/settings), it syncs the repo
 settings, labels, and branch protection ruleset described below from the committed
@@ -52,4 +53,33 @@ Under **Settings > Rules > Rulesets**, create a new ruleset:
 After the first successful Pages deployment, an environment named `github-pages` will exist under
 **Settings > Environments**. Open it and ensure **Deployment branches and tags** is set to
 **All branches** (no restriction).
+{%- endif %}
+{%- elif using_azdo %}
+
+If you chose `repo_setup_actions: None` (or need to reapply this after the fact), here's how to
+recreate what `Create Repo`/`Set Repo Rules` would otherwise set up automatically, through the
+Azure DevOps UI.
+
+## Pipelines
+
+Under **Pipelines > New pipeline**, create one pipeline per file under `.azurepipelines/`,
+pointing each at the matching YAML file in this repo. Name each `[{{ repo_name }}] <file-stem>`
+(e.g. `[{{ repo_name }}] pr_validation`) to match what this template's own automation would have
+named them.
+
+## PR-Validation Branch Policy
+
+Under **Project Settings > Repositories > (this repo) > Policies > Branch Policies > main**, add
+a **Build Validation** policy:
+
+- Build pipeline: the `pr_validation` pipeline created above
+- Trigger: **Automatic**
+- Policy requirement: **Required**
+- Build expiration: **Immediately**
+
+## Bypass Permission
+
+Under **Project Settings > Repositories > (this repo) > Security**, select **Project
+Administrators** and set **Bypass policies when completing pull requests** to **Allow** -- this
+lets project admins use the "Complete" button's bypass option instead of being blocked entirely.
 {%- endif %}

--- a/template/{% if is_template %}docs{% endif %}/platform_notes/azure_devops.md
+++ b/template/{% if is_template %}docs{% endif %}/platform_notes/azure_devops.md
@@ -15,7 +15,9 @@ Support for Azure DevOps is provided on a best-effort basis and has some limitat
     automatically on the default branch (the `pr_validation` pipeline must pass before a PR can
     complete), along with a **Project Administrators** bypass permission mirroring GitHub's
     admin `bypass_actors` entry. Unlike GitHub's ruleset, force-push and branch deletion on the
-    default branch are **not** blocked -- this is a known, currently-accepted gap
+    default branch are **not** blocked -- this is a known, currently-accepted gap. If you chose
+    `repo_setup_actions: None`, see [Manual Repo Settings](../manual_repo_settings.md) for how to
+    set this up by hand.
 - `zensical_target` is always `docs_site Directory in Repo`
   - `GitHub Pages` isn't offered, so Azure DevOps projects never get the release-versioned docs
     site that target provides — see [Getting Started](../index.md#documentation)


### PR DESCRIPTION
manual_repo_settings.md.jinja was unconditional GitHub-only content despite being linked from every is_template project's docs nav regardless of platform -- an Azure DevOps project choosing repo_setup_actions: None got a page entirely about GitHub UI steps that don't apply. Gate the GitHub content on using_github and add an Azure DevOps section covering how to manually recreate the pipelines, PR-validation branch policy, and admin bypass permission through the Azure DevOps UI, cross-referenced from azure_devops.md.