### PR TITLE
fix: cancel superseded PR-validation runs on new pushes

### DIFF
--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
@@ -1,14 +1,13 @@
 name: $(BuildId)-pr_validation
 
+# Azure Repos Git doesn't support YAML `pr:` triggers at all (they only work for GitHub/
+# Bitbucket Cloud sources) -- this pipeline is triggered solely by the "PR Validation"
+# build-validation branch policy set up in copier.yml.jinja's repo-setup tasks, so there's
+# no `pr:` block here and no `autoCancel` (a `pr:`-trigger-only feature) to rely on.
 trigger:
   branches:
     exclude:
       - "*"
-
-pr:
-  branches:
-    include:
-      - main
 
 variables:
   CI: true
@@ -24,6 +23,40 @@ stages:
         timeoutInMinutes: 60
         displayName: PR Validation
         steps:
+          - bash: |
+              # The branch-policy trigger above has no documented equivalent of GitHub's
+              # concurrency/cancel-in-progress or the YAML `pr:` trigger's autoCancel, so a
+              # rapid series of pushes to the same PR can leave multiple runs of this
+              # pipeline racing each other. Cancel any other still-running run of this same
+              # pipeline definition, triggered by a pull request, for the same source
+              # branch (Azure Repos only allows one open PR per source/target branch pair,
+              # so this reliably scopes to "this PR").
+              set -euo pipefail
+              API="$(System.CollectionUri)$(System.TeamProject)/_apis/build"
+              AUTH=(-u "user:$SYSTEM_ACCESSTOKEN")
+
+              THIS_BUILD=$(curl -sf "${AUTH[@]}" "$API/builds/$(Build.BuildId)?api-version=7.1")
+              DEFINITION_ID=$(echo "$THIS_BUILD" | jq -r '.definition.id')
+              SOURCE_BRANCH=$(echo "$THIS_BUILD" | jq -r '.sourceBranch')
+
+              OTHER_BUILDS=$(curl -sf "${AUTH[@]}" \
+                "$API/builds?definitions=${DEFINITION_ID}&reasonFilter=pullRequest&api-version=7.1")
+
+              echo "$OTHER_BUILDS" | jq -r --arg branch "$SOURCE_BRANCH" --arg id "$(Build.BuildId)" '
+                .value[]
+                | select(.sourceBranch == $branch)
+                | select(.status == "inProgress" or .status == "notStarted")
+                | select((.id | tostring) != $id)
+                | .id
+              ' | while read -r STALE_ID; do
+                echo "Cancelling superseded run $STALE_ID for this PR..."
+                curl -sf "${AUTH[@]}" -X PATCH -H "Content-Type: application/json" \
+                  -d '{"status": "cancelling"}' \
+                  "$API/builds/${STALE_ID}?api-version=7.1" > /dev/null
+              done
+            displayName: Cancel Superseded PR Validation Runs
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           - checkout: self
             fetchDepth: 0
           - bash: |


### PR DESCRIPTION
pr_validation.yml.jinja had a `pr:` trigger block that's dead code for this template's actual use case -- Azure Repos Git doesn't support YAML pr: triggers at all (GitHub/Bitbucket Cloud only per Microsoft's docs), so this pipeline is really invoked solely by the build-validation branch policy, which has no documented auto-cancel equivalent. Removed the dead pr: block and added an explicit first step that cancels any other in-progress/queued run of this same pipeline for the same PR before proceeding, via the Builds REST API, so rapid pushes don't leave multiple runs racing each other.