### PR TITLE
docs: remove github_org.md, its claimed limitations no longer exist

### DIFF
--- a/template/zensical.toml.jinja
+++ b/template/zensical.toml.jinja
@@ -14,7 +14,6 @@ nav = [
   { "Public vs Private Repos" = "public_vs_private_repos.md" },
   { "Platform Notes" = [
     "platform_notes/index.md",
-    "platform_notes/github_org.md",
     "platform_notes/azure_devops.md"
   ] },
   { "Components" = [

--- a/template/{% if is_template %}docs{% endif %}/index.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/index.md.jinja
@@ -27,7 +27,6 @@ See [Template Questions](template_questions.md) for what each prompt during that
 
 - GitHub **Recommended**
   - Creating repos under both users and orgs is supported
-  - See [GitHub Org Limitations](platform_notes/github_org.md) for details about template features excluded for Orgs
 - Azure DevOps **Deprecated**
   - See [Azure DevOps Limitations](platform_notes/azure_devops.md) for details about features missing for AzDO, and why this platform is being phased out
 

--- a/template/{% if is_template %}docs{% endif %}/platform_notes/github_org.md
+++ b/template/{% if is_template %}docs{% endif %}/platform_notes/github_org.md
@@ -1,8 +1,0 @@
-# GitHub Org Limitations
-
-There are several template features that are intentionally excluded for repositores made under GitHub organizations, detailed below:
-
-## Repo Settings
-
-- `Auto-merge for pull requests` is not set as it might conflict with org policies
-- `Delete branch on merge` is not set as it would require organization owner rights to set

--- a/template/{% if is_template %}docs{% endif %}/platform_notes/index.md
+++ b/template/{% if is_template %}docs{% endif %}/platform_notes/index.md
@@ -1,9 +1,7 @@
 # Platform Notes
 
-Each generated project targets one platform (GitHub or Azure DevOps), and that platform has a few
-quirks or intentional limitations worth knowing about:
+Each generated project targets one platform (GitHub or Azure DevOps). GitHub has no platform-
+specific quirks or limitations worth calling out here; Azure DevOps does:
 
-- [GitHub Org Limitations](github_org.md) — features excluded for repos made under a GitHub
-  organization.
 - [Azure DevOps Limitations](azure_devops.md) — features unavailable or unimplemented for Azure
   DevOps projects.

--- a/template/{% if is_template %}docs{% endif %}/template_questions.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/template_questions.md.jinja
@@ -12,8 +12,7 @@ Determines which platform-specific files get generated: GitHub gets `.github/wor
 Azure DevOps gets `.azurepipelines/`. This choice also locks out some other options — Azure DevOps
 projects can't use `GitHub Pages` for `zensical_target`, and `project_visibility` defaults to
 `Private` since Azure DevOps doesn't support public projects the same way. See
-[Azure DevOps Limitations](platform_notes/azure_devops.md) and
-[GitHub Org Limitations](platform_notes/github_org.md) for platform-specific details.
+[Azure DevOps Limitations](platform_notes/azure_devops.md) for platform-specific details.
 
 **Azure DevOps support is deprecated** and will eventually be removed from this template
 entirely. Prefer GitHub for new projects unless you specifically need Azure DevOps.


### PR DESCRIPTION
The page claimed auto-merge and delete-branch-on-merge were withheld for org-owned repos, but settings.yml.jinja sets both unconditionally (the auto-merge gate was deliberately removed in a prior change enabling it on all repos). With no other org-specific limitations to document, remove the page rather than leave a stale or empty one, and drop it from nav and all cross-references.