### PR TITLE
fix: scope AzDO PR validation's lint to changed files only

### DIFF
--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
@@ -34,7 +34,20 @@ stages:
             displayName: Install Mise
           - bash: mise install
             displayName: Run 'mise install'
-          - bash: mise x -- prek run -c .config/prek.toml --all-files
+          - bash: |
+              # Scopes the lint run to files actually changed on this PR, matching
+              # GitHub's counterpart (which uses tj-actions/changed-files for the same
+              # purpose) -- identical PR content could otherwise pass on GitHub and fail
+              # on Azure DevOps (or vice versa) depending on unrelated pre-existing lint
+              # state elsewhere in the repo.
+              git fetch origin $(System.PullRequest.TargetBranchName)
+              CHANGED_FILES=$(git diff --name-only "origin/$(System.PullRequest.TargetBranchName)...HEAD")
+              if [ -z "$CHANGED_FILES" ]; then
+                echo "No changed files detected; skipping prek."
+              else
+                echo "$CHANGED_FILES"
+                mise x -- prek run -c .config/prek.toml --files $CHANGED_FILES
+              fi
             displayName: Run Prek Tests
 {%- if is_template %}
           - bash: mise x -- pytest tests/


### PR DESCRIPTION
pr_validation.yml.jinja ran prek --all-files, unlike GitHub's counterpart which scopes to files actually changed on the PR (via tj-actions/ changed-files). Identical PR content could pass on GitHub and fail on Azure DevOps (or vice versa) depending on unrelated pre-existing lint state elsewhere in the repo. Compute the changed-file list via git diff against $(System.PullRequest.TargetBranchName) and pass it to --files, matching GitHub's behavior without adding a marketplace-task dependency.