### PR TITLE
fix: align AzDO pipeline timeouts with their GitHub counterparts

### DIFF
--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/copier-update-check.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/copier-update-check.yml
@@ -24,7 +24,7 @@ stages:
     displayName: Check for Template Update
     jobs:
       - job: checkfortemplateupdate
-        timeoutInMinutes: 60
+        timeoutInMinutes: 15
         displayName: Check for Template Update
         steps:
           - pwsh: |

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/docs.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/docs.yml.jinja
@@ -21,7 +21,10 @@ stages:
     displayName: Build Zensical
     jobs:
       - job: zensical_build
-        timeoutInMinutes: 60
+        # Higher than the other pipelines' 15 minutes: the "Wait for PR Validation Policy"
+        # step alone can poll for up to 20 minutes (40 attempts * 30s), on top of the
+        # actual pr_validation pipeline run and the steps before it.
+        timeoutInMinutes: 30
         displayName: Build Zensical
         steps:
           - pwsh: |

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
@@ -20,7 +20,7 @@ stages:
     displayName: PR Validation
     jobs:
       - job: pr_validation
-        timeoutInMinutes: 60
+        timeoutInMinutes: 15
         displayName: PR Validation
         steps:
           - bash: |

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/release.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/release.yml
@@ -17,7 +17,10 @@ stages:
     displayName: Release
     jobs:
       - job: release
-        timeoutInMinutes: 60
+        # Higher than the other pipelines' 15 minutes: the "Wait for PR Validation Policy"
+        # step alone can poll for up to 20 minutes (40 attempts * 30s), on top of the
+        # actual pr_validation pipeline run and the release steps before it.
+        timeoutInMinutes: 30
         displayName: Release
         steps:
           - pwsh: |

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/renovate.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/renovate.yml.jinja
@@ -28,7 +28,7 @@ stages:
     displayName: Renovate
     jobs:
       - job: renovate
-        timeoutInMinutes: 60
+        timeoutInMinutes: 15
         displayName: Renovate
         steps:
           - pwsh: |

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/{% if is_template and integration_test_scheduled %}integration_test.yml{% endif %}
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/{% if is_template and integration_test_scheduled %}integration_test.yml{% endif %}
@@ -23,7 +23,7 @@ stages:
     displayName: Integration Test
     jobs:
       - job: integration_test
-        timeoutInMinutes: 60
+        timeoutInMinutes: 15
         displayName: Integration Test
         steps:
           - pwsh: |


### PR DESCRIPTION
All seven AzDO pipelines used a uniform 60-minute timeout regardless of actual expected runtime. Align with GitHub's equivalents: 15 minutes for copier-update-check/pr_validation/renovate/integration_test (matching GitHub's own analogous jobs -- integration_test has no async polling, unlike GitHub's Settings-App-polling job), 30 for release/docs (both now poll the PR-validation policy for up to 20 minutes via A1, so they need real headroom above that ceiling).