### PR TITLE
fix: correct copier-update-check's display name and schedule

### DIFF
--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/copier-update-check.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/copier-update-check.yml
@@ -6,8 +6,9 @@ trigger:
       - "*"
 
 schedules:
-  - cron: 0 2 * * 1
-    displayName: Run 'copier update' Every Monday at 2am
+  # Matches maint-copier_update_check.yml's own schedule (5pm UTC every Monday).
+  - cron: 0 17 * * 1
+    displayName: Check for Copier Template Updates Every Monday at 5pm UTC
     branches:
       include:
         - main


### PR DESCRIPTION
displayName said "Run 'copier update'" but the pipeline only ever runs 'copier check-update', never a real update -- fix the wording. Also align its cron schedule with GitHub's maint-copier_update_check.yml (5pm UTC Monday) instead of the previous unrelated 2am UTC.