### PR TITLE
docs: fix GitHub-biased phrasing in docs/index.md.jinja

### DIFF
--- a/template/{% if is_template %}docs{% endif %}/index.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/index.md.jinja
@@ -52,7 +52,9 @@ It is highly encouraged for you to take this template and make your own child te
 - Setting of repo settings & branch protection rules
 - Creation of useful non-default issue labels: `awaiting pr` and `blocked`
 - Contributor management and crediting via [All Contributors](https://allcontributors.org/)
-- Dependency updates via [Renovate](https://github.com/marketplace/renovate/)
+- Dependency updates via [Renovate](https://www.mend.io/renovate/) -- the [GitHub Marketplace
+  App](https://github.com/marketplace/renovate/) on GitHub, a self-hosted scheduled pipeline on
+  Azure DevOps
 - Scheduled checks for updates from parent template
 
 ### Documentation
@@ -77,8 +79,10 @@ Rich Markdown documentation is pre-configured using [Zensical](https://zensical.
 
 ### CI/CD
 
-- Version number calculation, Changelog updating, releasing, and tagging via [Release Please](https://github.com/googleapis/release-please)
-- Simple/example release workflow via GitHub Actions
+- Version number calculation, changelog updating, releasing, and tagging via [Release
+  Please](https://github.com/googleapis/release-please) on GitHub, or
+  [Commitizen](https://commitizen-tools.github.io/commitizen/) on Azure DevOps
+- Simple/example release pipeline via GitHub Actions or Azure Pipelines
 
 ### Support Files
 


### PR DESCRIPTION
The Renovate and release-automation bullets described only their GitHub-side tooling (GitHub Marketplace App, Release Please) despite Azure DevOps having its own equivalent (a self-hosted pipeline, Commitizen) -- reword both for accuracy across platforms. The actionlint bullet was also flagged as GitHub-biased, but turned out accurate as written: this doc only ever renders for is_template projects, where mise.toml.jinja installs actionlint unconditionally (is_template or using_github), so no fix was needed there.