### PR TITLE
docs: document the missing Azure Pipelines semantic linter

### DIFF
--- a/template/{% if is_template %}docs{% endif %}/platform_notes/azure_devops.md
+++ b/template/{% if is_template %}docs{% endif %}/platform_notes/azure_devops.md
@@ -43,3 +43,8 @@ Support for Azure DevOps is provided on a best-effort basis and has some limitat
     DevOps-target one (it already has `AZURE_DEVOPS_EXT_PAT` wired up for exactly that). This is
     an intentional, accepted asymmetry, not a gap to close: a regression in GitHub-target
     scaffolding is still caught, just only by GitHub-hosted CI.
+- No semantic linter for Azure Pipelines YAML
+  - `.azurepipelines/*.yml` files get generic YAML syntax checking via `ryl`, but nothing checks
+    Azure Pipelines-specific schema/semantics the way `actionlint` does for GitHub Actions
+    workflows. No comparable standalone tool exists for Azure Pipelines, so this is treated as an
+    accepted limitation rather than a gap to close.


### PR DESCRIPTION
.azurepipelines/*.yml gets generic YAML syntax checking via ryl, but nothing checks Azure Pipelines-specific schema/semantics the way actionlint does for GitHub Actions -- no comparable standalone tool exists. Document it as an accepted, deliberate gap rather than a silent one.