### PR TITLE
docs: use direct links instead of reference-style in template_engine.md

### DIFF
--- a/template/{% if is_template %}docs{% endif %}/components/template_engine.md
+++ b/template/{% if is_template %}docs{% endif %}/components/template_engine.md
@@ -1,15 +1,11 @@
 # Why Copier?
 
-This template started out as a [Cookiecutter][cookiecutter] template, and was inspired by the [Hypermodern Python Cookiecutter][hypermodern-cc]. Cookiecutter is a great platform, but lacks several features, including:
+This template started out as a [Cookiecutter](https://github.com/cookiecutter/cookiecutter) template, and was inspired by the [Hypermodern Python Cookiecutter](https://github.com/cjolowicz/cookiecutter-hypermodern-python). Cookiecutter is a great platform, but lacks several features, including:
 
 - Conditional Questions
 - Template Updating
-  - This was available for Cookiecutters via [Cruft][cruft], but its featureset seemed to lag behind Cookiecutter's
+  - This was available for Cookiecutters via [Cruft](https://cruft.github.io/cruft/), but its featureset seemed to lag behind Cookiecutter's
 - Proper `.jinja` Extension for Templates
   - Because Cookiecutter didn't use a proper template extension, it caused larger problems for linters and formatters
 
 Copier provides these out of the box, and uses a friendly YAML syntax to boot. The Copier project also explicitly indicates that they want to be a language-agnostic templating engine, which is nice as the Postmodern template family is designed to be useful for any/all purposes.
-
-[cruft]: https://cruft.github.io/cruft/
-[cookiecutter]: https://github.com/cookiecutter/cookiecutter
-[hypermodern-cc]: https://github.com/cjolowicz/cookiecutter-hypermodern-python


### PR DESCRIPTION
Matches the rest of the docs, which already use direct [text](url) links throughout.