### PR TITLE
fix: pin a minimum required mise version

### DIFF
--- a/template/mise.toml.jinja
+++ b/template/mise.toml.jinja
@@ -1,3 +1,6 @@
+{#- renovate: datasource=github-releases depName=jdx/mise #}
+min_version = "2026.8.13"
+
 [hooks]
 {% raw %}postinstall = [
   "{% set is_in_ci = get_env(name='CI', default='') %}{% if is_in_ci %}echo 'Not setting up git hooks as mise is running in CI!'{% else %}prek install -f -c .config/prek.toml{% endif %}",


### PR DESCRIPTION
mise.toml uses features (hooks without experimental=true, task usage specs) that don't work on old mise installs, with no clear error message when they're missing -- min_version turns that into an explicit upgrade prompt. Pinned to the current latest (2026.8.13, confirmed via GitHub's releases API) with a Renovate comment so it gets bumped going forward, matching this repo's existing pin-and-let-Renovate-bump convention. Verified locally: mise hard- blocks with a clear message when unmet, and passes cleanly when met.