### PR TITLE
feat: scaffold code coverage reporting infrastructure

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -252,6 +252,11 @@ agent_instructions:
   type: bool
   help: Generate AGENTS.md/CLAUDE.md with instructions for AI coding agents.
   default: true
+
+code_coverage:
+  type: bool
+  help: Report code coverage via Codecov (GitHub) or Azure Pipelines' built-in publishing (Azure DevOps) -- wires up reporting only, your test command needs to produce coverage.xml (Cobertura) at the repo root.
+  default: false
 ## End Questions
 
 ## Start Computed Values
@@ -656,6 +661,9 @@ _message_after_copy: |-
   Before CI works, add these as GitHub Actions secrets (Settings > Secrets and variables > Actions):
     - REPO_MAINTENANCE_PAT
     - APPRISE_URL
+  {%- if code_coverage %}
+    - CODECOV_TOKEN
+  {%- endif %}
   {%- if is_template and integration_test_scheduled %}
     - INTEGRATION_TEST_PAT
     - AZURE_DEVOPS_EXT_PAT

--- a/template/mise.toml.jinja
+++ b/template/mise.toml.jinja
@@ -40,6 +40,9 @@ run = [
 {%- if using_github %}
   "gh secret set REPO_MAINTENANCE_PAT",
   "gh secret set APPRISE_URL",
+{%- if code_coverage %}
+  "gh secret set CODECOV_TOKEN",
+{%- endif %}
 {%- if is_template and integration_test_scheduled %}
   "gh secret set INTEGRATION_TEST_PAT",
   "gh secret set AZURE_DEVOPS_EXT_PAT",

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -265,6 +265,11 @@ agent_instructions:
   type: bool
   help: Generate AGENTS.md/CLAUDE.md with instructions for AI coding agents.
   default: true
+
+code_coverage:
+  type: bool
+  help: Report code coverage via Codecov (GitHub) or Azure Pipelines' built-in publishing (Azure DevOps) -- wires up reporting only, your test command needs to produce coverage.xml (Cobertura) at the repo root.
+  default: false
 ## End Questions
 
 ## Start Computed Values
@@ -669,6 +674,9 @@ _message_after_copy: |-
   Before CI works, add these as GitHub Actions secrets (Settings > Secrets and variables > Actions):
     - REPO_MAINTENANCE_PAT
     - APPRISE_URL
+  {%- if code_coverage %}
+    - CODECOV_TOKEN
+  {%- endif %}
   {%- if is_template and integration_test_scheduled %}
     - INTEGRATION_TEST_PAT
     - AZURE_DEVOPS_EXT_PAT

--- a/template/{% if is_template %}docs{% endif %}/prerequisites.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/prerequisites.md.jinja
@@ -61,6 +61,10 @@ In order to support the proper parsing of Conventional Commits, the following mu
     - This app syncs repo settings (labels, merge options, branch protection) from the committed `.github/settings.yml`, which is always generated for GitHub projects
     - It must have access to a repo *before* that repo is created for its settings to apply, so grant it access to all your repositories up front, same as the apps above
     - Skipping this is fine -- see [Manual Repo Settings](manual_repo_settings.md) for how to apply the same configuration by hand instead
+1. Install the [Codecov GitHub App](https://github.com/apps/codecov) for your user or organization.
+    - This app powers Codecov's PR comments/checks and connects your repo to codecov.io for uploads
+    - Only needed if you plan to answer Yes to the `code_coverage` question -- skip this if you don't want code coverage reporting
+    - It is recommended that you give it access to all your repositories, which means you only need to do this step once rather than for each new repo.
 1. Ensure `Private vulnerability reporting > Automatically enable for new public repositories` is checked [in the repo settings](https://github.com/settings/security_analysis).
 {%- endif %}
 

--- a/template/{% if is_template %}docs{% endif %}/template_questions.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/template_questions.md.jinja
@@ -90,3 +90,12 @@ Stable) prompts a one-time commit to bump Release Please's version past `1.0.0`.
 Whether to generate `AGENTS.md` (repo conventions for AI coding agents) and `CLAUDE.md` (a
 one-line `@AGENTS.md` import, so Claude Code picks up the same content). Choosing `No` skips
 both files entirely.
+
+## `code_coverage`: Yes / No
+
+Whether to wire up code coverage reporting: the Codecov GitHub Action on GitHub, or Azure
+Pipelines' built-in coverage publishing on Azure DevOps. This only plumbs the upload/publish
+step -- it expects a `coverage.xml` (Cobertura format) at the repo root, and doesn't produce
+one itself. Your own test command (or a language-specific child template built from this one)
+needs to actually generate that file, e.g. `pytest-cov`'s `--cov-report=xml` for Python or
+Pester's `-CodeCoverage` for PowerShell.

--- a/template/{% if is_template %}docs{% endif %}/token_permissions.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/token_permissions.md.jinja
@@ -17,6 +17,20 @@ validation failing to pass, since those pipelines merge without a human in the l
 an [Apprise](https://github.com/caronc/apprise) notification URL pointing at wherever you want
 these notifications sent (email, Slack, Discord, ntfy, Pushover, and 80+ others -- see Apprise's
 own docs for the URL format for your service of choice).
+
+## Code Coverage
+
+Only relevant if you answer Yes to the `code_coverage` question.
+{%- if using_github %}
+
+Reporting code coverage needs a secret called **CODECOV_TOKEN**. Sign up at
+[codecov.io](https://codecov.io), add this repo, and copy the repository upload token from its
+settings page.
+{%- elif using_azdo %}
+
+Reporting code coverage needs no secret or external service on Azure DevOps -- coverage
+publishing (`PublishCodeCoverageResults@2`) is a built-in Azure Pipelines feature.
+{%- endif %}
 {%- if using_github %}
 
 ## GitHub

--- a/template/{% if is_template %}tests{% endif %}/answer_matrix.py
+++ b/template/{% if is_template %}tests{% endif %}/answer_matrix.py
@@ -29,6 +29,7 @@ ANSWER_MATRIX = [
         "license": "MIT",
         "zensical_target": "GitHub Pages",
         "lifecycle": "Pre-Alpha",
+        "code_coverage": True,
     },
     {
         "id": "github-standard-private-none-docs_site-stable",
@@ -65,6 +66,7 @@ ANSWER_MATRIX = [
         "license": "None",
         "zensical_target": "docs_site Directory in Repo",
         "lifecycle": "Beta",
+        "code_coverage": True,
     },
     {
         "id": "azdo-standard-private-docs_site-alpha",

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
@@ -86,3 +86,10 @@ stages:
           - bash: mise x -- pytest tests/
             displayName: Run Template Render Tests
 {%- endif %}
+{%- if code_coverage %}
+          - task: PublishCodeCoverageResults@2
+            condition: succeededOrFailed()
+            inputs:
+              summaryFileLocation: $(Build.SourcesDirectory)/coverage.xml
+              failIfCoverageEmpty: false
+{%- endif %}

--- a/template/{% if using_github %}.github{% endif %}/workflows/test-pr_validation.yml.jinja
+++ b/template/{% if using_github %}.github{% endif %}/workflows/test-pr_validation.yml.jinja
@@ -30,3 +30,12 @@ jobs:
         run: |-
           mise x -- pytest tests/
 {%- endif %}
+{%- if code_coverage %}
+      - name: Upload Coverage to Codecov
+        if: {% raw %}${{ hashFiles('coverage.xml') != '' }}{% endraw %}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}
+          files: coverage.xml
+          fail_ci_if_error: false
+{%- endif %}


### PR DESCRIPTION
Adds a new code_coverage question (default No) that wires up the upload/publish half of coverage reporting -- Codecov on GitHub, Azure Pipelines' built-in coverage publishing on Azure DevOps -- without assuming any language. Both expect a Cobertura-format coverage.xml at the repo root; producing that file is left to the user's own test command or a language-specific child template built from this one, so those children only need to plug in their test tooling rather than wire up reporting from scratch.

Includes CODECOV_TOKEN secret plumbing (provision-secrets, after-copy message, token_permissions.md) and a Codecov GitHub App prerequisite bullet, both GitHub-only -- Azure DevOps needs neither a token nor an external service. codecov/codecov-action is pinned to v7.0.0's real commit SHA (verified via git ls-remote, dereferencing the annotated tag). Live upload/publish behavior can't be verified from this sandbox -- only render, lint, and structural correctness are.