### PR TITLE
docs: stop fencing pre-render docs on questions not yet answered

### DIFF
--- a/template/{% if is_template %}docs{% endif %}/manual_repo_settings.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/manual_repo_settings.md.jinja
@@ -1,5 +1,6 @@
 # Manual Repo Settings
-{%- if using_github %}
+
+## GitHub
 
 When you use the [Settings GitHub App](https://github.com/apps/settings), it syncs the repo
 settings, labels, and branch protection ruleset described below from the committed
@@ -8,7 +9,7 @@ not been approved for your organization), here's how to apply the same configura
 through the GitHub UI. `.github/settings.yml` is the source of truth for the exact values below --
 if the two ever disagree, trust the file.
 
-## Labels
+### Labels
 
 Under the repo's **Issues** tab, open **Labels**, and create:
 
@@ -17,14 +18,14 @@ Under the repo's **Issues** tab, open **Labels**, and create:
 | `awaiting pr` | `#668F04` | Awaiting completion of a PR from a contributor |
 | `blocked` | `#B60205` | Blocked by an external dependency |
 
-## Merge Options
+### Merge Options
 
 Under **Settings > General > Pull Requests**, enable:
 
 - **Allow auto-merge**
 - **Automatically delete head branches**
 
-## Branch Protection
+### Branch Protection
 
 Under **Settings > Rules > Rulesets**, create a new ruleset:
 
@@ -46,28 +47,29 @@ Under **Settings > Rules > Rulesets**, create a new ruleset:
 - Bypass list: add **Repository admin**, with bypass mode **Pull requests only** -- this lets
   repo admins use the "Merge without waiting for requirements to be met" button instead of being
   blocked entirely.
-{%- if zensical_ghpages %}
 
-## GitHub Pages Environment
+### GitHub Pages Environment
+
+(`zensical_target: GitHub Pages` only.)
 
 After the first successful Pages deployment, an environment named `github-pages` will exist under
 **Settings > Environments**. Open it and ensure **Deployment branches and tags** is set to
 **All branches** (no restriction).
-{%- endif %}
-{%- elif using_azdo %}
+
+## Azure DevOps
 
 If you chose `repo_setup_actions: None` (or need to reapply this after the fact), here's how to
 recreate what `Create Repo`/`Set Repo Rules` would otherwise set up automatically, through the
 Azure DevOps UI.
 
-## Pipelines
+### Pipelines
 
 Under **Pipelines > New pipeline**, create one pipeline per file under `.azurepipelines/`,
 pointing each at the matching YAML file in this repo. Name each `[{{ repo_name }}] <file-stem>`
 (e.g. `[{{ repo_name }}] pr_validation`) to match what this template's own automation would have
 named them.
 
-## PR-Validation Branch Policy
+### PR-Validation Branch Policy
 
 Under **Project Settings > Repositories > (this repo) > Policies > Branch Policies > main**, add
 a **Build Validation** policy:
@@ -77,9 +79,8 @@ a **Build Validation** policy:
 - Policy requirement: **Required**
 - Build expiration: **Immediately**
 
-## Bypass Permission
+### Bypass Permission
 
 Under **Project Settings > Repositories > (this repo) > Security**, select **Project
 Administrators** and set **Bypass policies when completing pull requests** to **Allow** -- this
 lets project admins use the "Complete" button's bypass option instead of being blocked entirely.
-{%- endif %}

--- a/template/{% if is_template %}docs{% endif %}/prerequisites.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/prerequisites.md.jinja
@@ -1,5 +1,4 @@
 # Prerequisites
-{%- if using_azdo %}
 
 ## Azure DevOps
 
@@ -33,8 +32,6 @@ In order to support the proper parsing of Conventional Commits, the following mu
                     - Contribute
                     - Contribute to pull requests
                     - Create branch
-{%- endif %}
-{%- if using_github %}
 
 ## GitHub
 
@@ -62,17 +59,10 @@ In order to support the proper parsing of Conventional Commits, the following mu
     - It must have access to a repo *before* that repo is created for its settings to apply, so grant it access to all your repositories up front, same as the apps above
     - Skipping this is fine -- see [Manual Repo Settings](manual_repo_settings.md) for how to apply the same configuration by hand instead
 1. Ensure `Private vulnerability reporting > Automatically enable for new public repositories` is checked [in the repo settings](https://github.com/settings/security_analysis).
-{%- endif %}
 
 ## Personal Access Tokens
-{%- if using_azdo %}
 
-Azure DevOps no longer needs one for repo setup -- see the `az login` step above. See
-[Token Permissions](token_permissions.md) for the permissions the signed-in account needs instead.
-{%- endif %}
-{%- if using_github %}
-
-GitHub no longer needs one for repo setup -- see the `gh auth login` step above. See
-[Token Permissions](token_permissions.md) for the separate, ongoing **Repo Maintenance PAT** used
-by this project's own GitHub Actions workflows.
-{%- endif %}
+Neither platform needs one for repo setup anymore -- see the `az login`/`gh auth login` steps
+above. See [Token Permissions](token_permissions.md) for the permissions the signed-in account
+needs instead on Azure DevOps, and for the separate, ongoing **Repo Maintenance PAT** used by
+this project's own GitHub Actions workflows.

--- a/template/{% if is_template %}docs{% endif %}/token_permissions.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/token_permissions.md.jinja
@@ -11,13 +11,13 @@ any time, e.g. to rotate a token.
 
 ## Notifications
 
-Both platforms' Copier update-check job{% if using_azdo %}, the Azure DevOps Renovate pipeline, and
-the Azure DevOps release/docs pipelines (which notify on both successful auto-merge and on PR
-validation failing to pass, since those pipelines merge without a human in the loop) need{% else %} needs{% endif %} a secret/variable called **APPRISE_URL**. Unlike the tokens below, it isn't a scope to grant -- it's
-an [Apprise](https://github.com/caronc/apprise) notification URL pointing at wherever you want
-these notifications sent (email, Slack, Discord, ntfy, Pushover, and 80+ others -- see Apprise's
-own docs for the URL format for your service of choice).
-{%- if using_github %}
+Both platforms' Copier update-check job needs a secret/variable called **APPRISE_URL**. Azure
+DevOps additionally needs it for the Renovate pipeline and the release/docs pipelines, since
+those merge without a human in the loop and notify on both successful auto-merge and on PR
+validation failing to pass. Unlike the tokens below, it isn't a scope to grant -- it's an
+[Apprise](https://github.com/caronc/apprise) notification URL pointing at wherever you want these
+notifications sent (email, Slack, Discord, ntfy, Pushover, and 80+ others -- see Apprise's own
+docs for the URL format for your service of choice).
 
 ## GitHub
 
@@ -44,9 +44,10 @@ Actions workflows (Copier update checks, Release Please), not just at setup time
 | repo                          | Needed for Copier/Release Please workflows |
 
 NOTE: Fine-grained tokens are specifically **not** used, as they cannot open pull requests. This can be changed once [this issue](https://github.com/github/roadmap/issues/600) is implemented by GitHub.
-{%- if is_template %}
 
 ### Integration Test PAT (Classic Token)
+
+(Template projects with `integration_test_scheduled` only.)
 
 Create this token the same way as the Repo Maintenance PAT above and save it as a GitHub Actions
 secret called **INTEGRATION_TEST_PAT**. Used by `test-integration_test.yml`, which creates a
@@ -70,6 +71,8 @@ never automatically gains access to a repo created after the fact.
 
 ### Integration Test PAT for Azure DevOps
 
+(Template projects with `integration_test_scheduled` only.)
+
 `test-integration_test.yml` also runs a second job that creates a throwaway repo with
 `developer_platform=Azure DevOps` to verify that path end to end, regardless of which platform
 this project itself uses. Create an Azure DevOps PAT covering **Code (Full)** and **Build (Read &
@@ -83,9 +86,6 @@ its own pipeline variables), so also edit the `integration-test-azdo` job's `env
 in `test-integration_test.yml`, replacing the `AZDO_INTEGRATION_TEST_ORG`/`AZDO_INTEGRATION_TEST_PROJECT`
 placeholder values with your real org/project -- left as placeholders, the job fails fast with an
 explanatory error instead of a confusing `az` CLI one.
-{%- endif %}
-{%- endif %}
-{%- if using_azdo %}
 
 ## Azure DevOps
 
@@ -98,4 +98,14 @@ enough permission in the target project to create repos and pipelines (typically
 Administrator**, or an equivalent custom permission set covering `Code: Full` and
 `Build: Read & Execute`). The initial `git push` is a separate matter -- `az login` doesn't bridge
 into git's credentials, so that step uses Git Credential Manager's own login instead.
-{%- endif %}
+
+### Integration Test Pipeline Variable
+
+(Template projects with `integration_test_scheduled` only.)
+
+The `integration_test` pipeline needs a secret pipeline variable called **AZURE_DEVOPS_EXT_PAT**,
+covering **Code (Full)** and **Build (Read & execute)** for the org/project it runs in -- the same
+permissions a signed-in `az login` session would need for repo/pipeline creation, just via a PAT
+since CI can't do an interactive login. This is the Azure DevOps counterpart to the GitHub
+Integration Test PAT above: it verifies the `developer_platform=Azure DevOps` path end to end,
+regardless of which platform this project itself uses.


### PR DESCRIPTION
prerequisites.md.jinja, token_permissions.md.jinja, and manual_repo_settings.md.jinja hid entire platform sections behind using_github/using_azdo (and, in one case, is_template/zensical_ghpages) conditionals -- but these docs are read before the questionnaire runs, so a prospective user can't see the section for the platform they haven't picked yet. Both platforms now always render, with applicability noted in prose instead.

Also documents AZURE_DEVOPS_EXT_PAT for Azure DevOps template projects' own integration_test pipeline, previously missing from token_permissions.md.jinja entirely.