### PR TITLE
fix: quote changed-file paths passed to prek in CI

### DIFF
--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
@@ -69,17 +69,17 @@ stages:
             displayName: Run 'mise install'
           - bash: |
               # Scopes the lint run to files actually changed on this PR, matching
-              # GitHub's counterpart (which uses tj-actions/changed-files for the same
-              # purpose) -- identical PR content could otherwise pass on GitHub and fail
-              # on Azure DevOps (or vice versa) depending on unrelated pre-existing lint
-              # state elsewhere in the repo.
+              # GitHub's counterpart (which runs the same git diff) -- identical PR
+              # content could otherwise pass on GitHub and fail on Azure DevOps (or vice
+              # versa) depending on unrelated pre-existing lint state elsewhere in the repo.
               git fetch origin $(System.PullRequest.TargetBranchName)
               CHANGED_FILES=$(git diff --name-only "origin/$(System.PullRequest.TargetBranchName)...HEAD")
               if [ -z "$CHANGED_FILES" ]; then
                 echo "No changed files detected; skipping prek."
               else
                 echo "$CHANGED_FILES"
-                mise x -- prek run -c .config/prek.toml --files $CHANGED_FILES
+                mapfile -t FILES <<< "$CHANGED_FILES"
+                mise x -- prek run -c .config/prek.toml --files "${FILES[@]}"
               fi
             displayName: Run Prek Tests
 {%- if is_template %}

--- a/template/{% if using_github %}.github{% endif %}/workflows/test-pr_validation.yml.jinja
+++ b/template/{% if using_github %}.github{% endif %}/workflows/test-pr_validation.yml.jinja
@@ -20,11 +20,19 @@ jobs:
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
         with:
           experimental: true
-      - id: changed-files
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
       - name: Run Prek Tests
+        env:
+          BASE_REF: {% raw %}${{ github.base_ref }}{% endraw %}
         run: |
-          mise x -- prek run -c .config/prek.toml --files {% raw %}${{ steps.changed-files.outputs.all_changed_files }}{% endraw %}
+          git fetch origin "$BASE_REF"
+          CHANGED_FILES=$(git diff --name-only "origin/$BASE_REF...HEAD")
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No changed files detected; skipping prek."
+          else
+            echo "$CHANGED_FILES"
+            mapfile -t FILES <<< "$CHANGED_FILES"
+            mise x -- prek run -c .config/prek.toml --files "${FILES[@]}"
+          fi
 {%- if is_template %}
       - name: Run Template Render Tests
         run: |-


### PR DESCRIPTION
Unquoted expansion split each changed-file path on whitespace before handing it to prek's --files flag, breaking on any path containing a space -- including this repo's own Jinja-conditional directory names under template/. Both platforms now build a proper bash array via mapfile before invoking prek.

Also drops tj-actions/changed-files from the GitHub workflow in favor of the same git diff the Azure DevOps pipeline already runs, so both platforms use identical logic instead of two separately-maintained mechanisms.