### PR TITLE
feat: enable CodeQL code scanning for public GitHub repos

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -645,6 +645,16 @@ _tasks:
       {%- if _copier_operation == 'copy' and zensical_ghpages and repo_setup_actions != 'None' -%}
         true
       {%- endif %}
+
+  # Enables CodeQL code scanning's default setup -- free for public repos, needs
+  # GitHub Advanced Security (paid) on private ones, so scoped to public only.
+  - command: >-
+      gh api repos/{{ github_repo_owner }}/{{ repo_name }}/code-scanning/default-setup
+      -X PATCH -f state=configured
+    when: |-
+      {%- if _copier_operation == 'copy' and is_public and using_github and repo_setup_actions != 'None' -%}
+        true
+      {%- endif %}
 ## End Tasks
 
 ## Start Messages

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -658,6 +658,16 @@ _tasks:
       {%- if _copier_operation == 'copy' and zensical_ghpages and repo_setup_actions != 'None' -%}
         true
       {%- endif %}
+
+  # Enables CodeQL code scanning's default setup -- free for public repos, needs
+  # GitHub Advanced Security (paid) on private ones, so scoped to public only.
+  - command: >-
+      gh api repos/{{ github_repo_owner }}/{{ repo_name }}/code-scanning/default-setup
+      -X PATCH -f state=configured
+    when: |-
+      {%- if _copier_operation == 'copy' and is_public and using_github and repo_setup_actions != 'None' -%}
+        true
+      {%- endif %}
 ## End Tasks
 
 ## Start Messages

--- a/template/{% if is_template %}docs{% endif %}/template_questions.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/template_questions.md.jinja
@@ -24,8 +24,9 @@ only) is always generated regardless of this answer -- see below. Choosing anyth
 triggers this question's validator, which checks the relevant platform CLI (`gh` or `az`) is
 installed and authenticated *before* letting you proceed -- see [Prerequisites](prerequisites.md).
 
-- **Create Repo** — creates the remote repo; on GitHub also sets Actions workflow permissions and
-  sets up GitHub Pages if applicable; on Azure DevOps also registers pipelines for each file under
+- **Create Repo** — creates the remote repo; on GitHub also sets Actions workflow permissions,
+  sets up GitHub Pages if applicable, and enables CodeQL code scanning's default setup if the
+  repo is public; on Azure DevOps also registers pipelines for each file under
   `.azurepipelines/`.
 - **Set Repo Rules** — skips repo creation (for an existing repo) but still applies the other
   automation above.


### PR DESCRIPTION
Adds a repo-setup task that PATCHes the code-scanning/default-setup endpoint for public repos, alongside the existing GitHub Pages setup task. Scoped to public repos since GitHub Advanced Security (needed for private repos) is a paid feature. Not configurable via the Settings GitHub App/settings.yml -- default setup is a separate API the app's plugin schema doesn't cover.