### PR TITLE
feat: enable private vulnerability reporting for public GitHub repos

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -645,6 +645,15 @@ _tasks:
       {%- if _copier_operation == 'copy' and zensical_ghpages and repo_setup_actions != 'None' -%}
         true
       {%- endif %}
+
+  # Lets anyone privately report a security vulnerability (Security > Advisories)
+  # instead of only via a public issue -- meaningful for public repos specifically,
+  # since a private repo's issues are already restricted to invited collaborators.
+  - command: gh api repos/{{ github_repo_owner }}/{{ repo_name }}/private-vulnerability-reporting -X PUT
+    when: |-
+      {%- if _copier_operation == 'copy' and is_public and using_github and repo_setup_actions != 'None' -%}
+        true
+      {%- endif %}
 ## End Tasks
 
 ## Start Messages

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -658,6 +658,15 @@ _tasks:
       {%- if _copier_operation == 'copy' and zensical_ghpages and repo_setup_actions != 'None' -%}
         true
       {%- endif %}
+
+  # Lets anyone privately report a security vulnerability (Security > Advisories)
+  # instead of only via a public issue -- meaningful for public repos specifically,
+  # since a private repo's issues are already restricted to invited collaborators.
+  - command: gh api repos/{{ github_repo_owner }}/{{ repo_name }}/private-vulnerability-reporting -X PUT
+    when: |-
+      {%- if _copier_operation == 'copy' and is_public and using_github and repo_setup_actions != 'None' -%}
+        true
+      {%- endif %}
 ## End Tasks
 
 ## Start Messages

--- a/template/{% if is_template %}docs{% endif %}/prerequisites.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/prerequisites.md.jinja
@@ -62,7 +62,6 @@ In order to support the proper parsing of Conventional Commits, the following mu
     - This app powers Codecov's PR comments/checks and connects your repo to codecov.io for uploads
     - Only needed if you plan to answer Yes to the `code_coverage` question -- skip this if you don't want code coverage reporting
     - It is recommended that you give it access to all your repositories, which means you only need to do this step once rather than for each new repo.
-1. Ensure `Private vulnerability reporting > Automatically enable for new public repositories` is checked [in the repo settings](https://github.com/settings/security_analysis).
 
 ## Personal Access Tokens
 

--- a/template/{% if is_template %}docs{% endif %}/template_questions.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/template_questions.md.jinja
@@ -24,9 +24,9 @@ only) is always generated regardless of this answer -- see below. Choosing anyth
 triggers this question's validator, which checks the relevant platform CLI (`gh` or `az`) is
 installed and authenticated *before* letting you proceed -- see [Prerequisites](prerequisites.md).
 
-- **Create Repo** — creates the remote repo; on GitHub also sets Actions workflow permissions and
-  sets up GitHub Pages if applicable; on Azure DevOps also registers pipelines for each file under
-  `.azurepipelines/`.
+- **Create Repo** — creates the remote repo; on GitHub also sets Actions workflow permissions,
+  sets up GitHub Pages if applicable, and enables private vulnerability reporting if the repo is
+  public; on Azure DevOps also registers pipelines for each file under `.azurepipelines/`.
 - **Set Repo Rules** — skips repo creation (for an existing repo) but still applies the other
   automation above.
 - **None** — skips all of it; you're on your own for repo creation and settings.


### PR DESCRIPTION
Adds a repo-setup task that PUTs the private-vulnerability-reporting endpoint for public repos, alongside the existing GitHub Pages/CodeQL setup tasks -- not configurable via the Settings GitHub App, since it's a dedicated endpoint outside the repo PATCH schema. Drops the now-redundant manual prerequisite for the org-level default, since this template enables it directly per-repo.