### PR TITLE
feat: enable secret scanning for public GitHub repos

### DIFF
--- a/template/{% if is_template %}docs{% endif %}/manual_repo_settings.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/manual_repo_settings.md.jinja
@@ -56,6 +56,12 @@ After the first successful Pages deployment, an environment named `github-pages`
 **Settings > Environments**. Open it and ensure **Deployment branches and tags** is set to
 **All branches** (no restriction).
 
+### Security and Analysis
+
+(Public repos only -- private repos need a paid GitHub Advanced Security license.)
+
+Under **Settings > Code security**, enable **Secret scanning** and **Push protection**.
+
 ## Azure DevOps
 
 If you chose `repo_setup_actions: None` (or need to reapply this after the fact), here's how to

--- a/template/{% if using_github %}.github{% endif %}/settings.yml.jinja
+++ b/template/{% if using_github %}.github{% endif %}/settings.yml.jinja
@@ -12,6 +12,18 @@ repository:
   allow_merge_commit: false
   allow_rebase_merge: false
   delete_branch_on_merge: true
+{%- if is_public %}
+
+  # Free for public repos; needs a paid GitHub Advanced Security license on private
+  # ones, so scoped to public only. New public repos under a personal account get
+  # this by default already, but org-owned ones don't -- this makes it explicit
+  # either way rather than depending on that default.
+  security_and_analysis:
+    secret_scanning:
+      status: enabled
+    secret_scanning_push_protection:
+      status: enabled
+{%- endif %}
 
 # The Settings App treats this list as authoritative: any label that exists on the
 # repo but isn't listed here gets deleted on sync -- including GitHub's own


### PR DESCRIPTION
Adds security_and_analysis (secret scanning + push protection) to settings.yml.jinja for public repos, synced by the Settings GitHub App -- unlike CodeQL default setup and private vulnerability reporting, this one is a normal PATCH /repos field the app already forwards, so no repo-setup task is needed. Covers the gap where GitHub's own default-on behavior only applies to personal-account repos, not org-owned ones.