### PR TITLE
feat: pin and Renovate-track copier.yml's min_copier_version

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -4,10 +4,8 @@ _answers_file: .config/copier-answers.yml
 _jinja_extensions:
   - jinja2_shell_extension.ShellExtension
 
-# mise.toml's `set-lifecycle` task depends on the `--ask` flag (copier-org/copier#2705),
-# which shipped in 9.17.0 -- newer than the `:current:` VCS ref sentinel it also needs
-# (copier-org/copier#2136, 9.8.0), so 9.17.0 is the effective floor.
-_min_copier_version: "9.17.0"
+# renovate: datasource=pypi depName=copier
+_min_copier_version: "9.17.2"
 
 _message_before_copy: Thanks for using this template! Please consult the 'Template Questions' page in documentation for deeper explanation of each question.
 

--- a/mise.toml
+++ b/mise.toml
@@ -93,7 +93,7 @@ rumdl = "0.2.52"
 shellcheck = "0.11.0"
 
 [tools."pipx:copier"]
-version = "9.17.1"
+version = "9.17.2"
 uvx_args = "--with jinja2-shell-extension==2.1.1"
 
 [tools."pipx:pytest"]

--- a/template/mise.toml.jinja
+++ b/template/mise.toml.jinja
@@ -139,7 +139,7 @@ rumdl = "0.2.52"
 shellcheck = "0.11.0"
 
 [tools."pipx:copier"]
-version = "9.17.1"
+version = "9.17.2"
 uvx_args = "--with jinja2-shell-extension==2.1.1"
 {%- if is_template %}
 

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -210,6 +210,17 @@
       "versioningTemplate": {% raw %}"{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"{% endraw %}
     },
     {
+      "description": "Manager for a Template project's own copier.yml min_copier_version pin",
+      "customType": "regex",
+      "managerFilePatterns": [
+        {% raw %}"/(^|/)(?:{%.*%})?copier\\.yml(?:{%.*%})?(?:\\.jinja)?$/"{% endraw %}
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s*\\n_min_copier_version:\\s*[\"'](?<currentValue>[^\"']*)[\"']"
+      ],
+      "versioningTemplate": {% raw %}"{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"{% endraw %}
+    },
+    {
       "description": "Manager for pipx git-sourced tools",
       "customType": "regex",
       "managerFilePatterns": [

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -12,10 +12,8 @@ _answers_file: .config/copier-answers.yml
 _jinja_extensions:
   - jinja2_shell_extension.ShellExtension
 
-# mise.toml's `set-lifecycle` task depends on the `--ask` flag (copier-org/copier#2705),
-# which shipped in 9.17.0 -- newer than the `:current:` VCS ref sentinel it also needs
-# (copier-org/copier#2136, 9.8.0), so 9.17.0 is the effective floor.
-_min_copier_version: "9.17.0"
+# renovate: datasource=pypi depName=copier
+_min_copier_version: "9.17.2"
 
 _message_before_copy: Thanks for using this template! Please consult the 'Template Questions' page in documentation for deeper explanation of each question.
 


### PR DESCRIPTION
Bumps _min_copier_version to the latest release (9.17.2) and adds a plain `# renovate: ...` comment, which survives rendering -- so a dedicated customManager tracks it in both the .jinja source and any Template project's own rendered copier.yml, root copier.yml included. Bumps mise.toml.jinja's pinned copier tool to match, so this repo's own tooling stays above its own copier.yml's new minimum.