### PR TITLE
fix: replace .gitattributes eol=lf with a prek hook

### DIFF
--- a/template/.config/prek.toml.jinja
+++ b/template/.config/prek.toml.jinja
@@ -138,6 +138,11 @@ id = "fix-byte-order-marker"
 
 [[repos.hooks]]
 id = "mixed-line-ending"
+# Replaces a repo-wide `* text eol=lf` .gitattributes rule, which can corrupt binary
+# files (e.g. images) that Git's own text-detection heuristic misclassifies -- this
+# hook's `types: [text]` filter (from pre-commit-hooks' own default) uses the more
+# reliable `identify` library instead, and never touches a file it can't confirm is text.
+args = ["--fix=lf"]
 
 [[repos.hooks]]
 id = "trailing-whitespace"

--- a/template/.gitattributes
+++ b/template/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf


### PR DESCRIPTION
A repo-wide `* text eol=lf` .gitattributes rule can corrupt binary files (e.g. images) that Git's own text-detection heuristic misclassifies. The mixed-line-ending prek hook's --fix=lf normalizes every non-LF line ending to LF (verified against its actual source, not just docs), and its types: [text] filter uses the identify library's more reliable detection -- enforced in CI, same as every other prek hook.