### PR TITLE
refactor: rename is_prerelease to lifecycle_is_pre_stable

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -329,7 +329,7 @@ is_template:
     {%- endif %}
   when: false
 
-is_prerelease:
+lifecycle_is_pre_stable:
   type: bool
   default: |-
     {%- if lifecycle == 'Pre-Alpha' or lifecycle == 'Alpha' or lifecycle == 'Beta' -%}
@@ -453,7 +453,7 @@ _tasks:
 
   # Commits template files
   - command: >-
-      {%- set release_as_version = "0.1.0" if is_prerelease else "1.0.0" -%}
+      {%- set release_as_version = "0.1.0" if lifecycle_is_pre_stable else "1.0.0" -%}
       git commit -m "feat: initialize project"
       {%- if using_github %} -m "Release-As: {{ release_as_version }}"{% endif %}
     when: *when_copy_create_repo

--- a/template/{% if is_standard %}README.md{% endif %}.jinja
+++ b/template/{% if is_standard %}README.md{% endif %}.jinja
@@ -3,7 +3,7 @@
 
 [![All Contributors](https://img.shields.io/github/all-contributors/{{ github_repo_owner }}/{{ repo_name }}?color=ee8449&style=flat-square)](#contributors)
 {%- endif -%}
-{%- if is_prerelease %}
+{%- if lifecycle_is_pre_stable %}
 
 <!-- Don't edit/remove this yourself! This is managed by the 'lifecycle' Copier answer. -->
 

--- a/template/{% if is_template %}README.md{% endif %}.jinja
+++ b/template/{% if is_template %}README.md{% endif %}.jinja
@@ -3,7 +3,7 @@
 
 [![All Contributors](https://img.shields.io/github/all-contributors/{{ github_repo_owner }}/{{ repo_name }}?color=ee8449&style=flat-square)](#contributors)
 {%- endif -%}
-{%- if is_prerelease %}
+{%- if lifecycle_is_pre_stable %}
 
 <!-- Don't edit/remove this yourself! See docs/lifecycle_management.md -->
 

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -342,7 +342,7 @@ is_template:
     {%- endif %}
   when: false
 
-is_prerelease:
+lifecycle_is_pre_stable:
   type: bool
   default: |-
     {%- if lifecycle == 'Pre-Alpha' or lifecycle == 'Alpha' or lifecycle == 'Beta' -%}
@@ -466,7 +466,7 @@ _tasks:
 
   # Commits template files
   - command: >-
-      {%- set release_as_version = "0.1.0" if is_prerelease else "1.0.0" -%}
+      {%- set release_as_version = "0.1.0" if lifecycle_is_pre_stable else "1.0.0" -%}
       git commit -m "feat: initialize project"
       {%- if using_github %} -m "Release-As: {{ release_as_version }}"{% endif %}
     when: *when_copy_create_repo


### PR DESCRIPTION
The variable never meant "this is a semver prerelease" -- it means "the lifecycle answer is Pre-Alpha/Alpha/Beta," gating the README's not-yet-stable banner and the initial commit's 0.1.0-vs-1.0.0 choice. The old name invited confusion with an actual prerelease identifier (e.g. 1.2.0-alpha.1), a distinct, unrelated concept.