### PR TITLE
fix: correct knope's mise pin to its per-crate monorepo tag format

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -84,6 +84,13 @@
       "groupName": "copier"
     },
     {
+      "description": "Group knope",
+      "matchPackageNames": [
+        "knope-dev/knope"
+      ],
+      "groupName": "knope"
+    },
+    {
       "description": "Group lychee",
       "matchPackageNames": [
         "lychee",
@@ -186,6 +193,45 @@
       ],
       "matchStrings": [
         "{#[-]? renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s*#}\\s+[A-Za-z0-9_\\-\"':/]+\\s?=\\s?[\"'](?<currentValue>[^\"']*)[\"'].*"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
+    },
+    {
+      "description": "Manager for the knope mise tool pin -- knope-dev/knope is a monorepo that tags each crate's releases separately (e.g. knope/vX.Y.Z), so the generic \"simple mise tools\" manager above can't be used: extractVersionTemplate is what filters the mixed-prefix tags down to just knope's own",
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "knope-dev/knope",
+      "extractVersionTemplate": "^knope/v(?<version>.*)$",
+      "managerFilePatterns": [
+        "/mise\\..*toml(?:{%.*%})?\\.jinja/"
+      ],
+      "matchStrings": [
+        "\"github:knope-dev/knope\"\\s*=\\s*\"knope/v(?<currentValue>[^\"]*)\""
+      ],
+      "versioningTemplate": "semver"
+    },
+    {
+      "description": "Manager for the knope version pin in the Knope-based release workflows",
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "knope-dev/knope",
+      "extractVersionTemplate": "^knope/v(?<version>.*)$",
+      "managerFilePatterns": [
+        "/(^|/)(?:{%.*%})?\\.github(?:{%.*%})?/workflows/.*knope.*\\.ya?ml(?:{%.*%})?(?:\\.jinja)?$/"
+      ],
+      "matchStrings": [
+        "version:\\s*(?<currentValue>[\\d.]+)"
+      ],
+      "versioningTemplate": "semver"
+    },
+    {
+      "description": "Manager for a Template project's own copier.yml min_copier_version pin",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)(?:{%.*%})?copier\\.yml(?:{%.*%})?(?:\\.jinja)?$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s*\\n_min_copier_version:\\s*[\"'](?<currentValue>[^\"']*)[\"']"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
     },

--- a/template/mise.toml.jinja
+++ b/template/mise.toml.jinja
@@ -118,9 +118,12 @@ actionlint = "1.7.12"
 "aqua:cli/cli" = "2.97.0"
 {#- Used by _tasks in copier.yml (repo bootstrap) and the maint-*knope*.yml workflows
    for the release flow. ubi is deprecated in mise and knope isn't in the aqua
-   registry, so this uses the github backend directly. #}
-{#- renovate: datasource=github-releases depName=knope-dev/knope #}
-"github:knope-dev/knope" = "v0.23.0"
+   registry, so this uses the github backend directly. knope-dev/knope is a monorepo
+   that tags each crate's releases separately (e.g. "knope/vX.Y.Z", not a bare
+   "vX.Y.Z") -- tracked by the dedicated "Manager for the knope mise tool pin"
+   customManager in renovate.json.jinja, not the generic "simple mise tools" one,
+   since that can't filter a monorepo's mixed-prefix tags. #}
+"github:knope-dev/knope" = "knope/v0.23.0"
 {%- endif %}
 {#- renovate: datasource=github-releases depName=crate-ci/typos #}
 "aqua:crate-ci/typos" = "1.49.0"

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -92,6 +92,13 @@
       "groupName": "copier"
     },
     {
+      "description": "Group knope",
+      "matchPackageNames": [
+        "knope-dev/knope"
+      ],
+      "groupName": "knope"
+    },
+    {
       "description": "Group lychee",
       "matchPackageNames": [
         "lychee",
@@ -208,6 +215,34 @@
         {% raw %}"{#[-]? renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s*#}\\s+[A-Za-z0-9_\\-\"':/]+\\s?=\\s?[\"'](?<currentValue>[^\"']*)[\"'].*"{% endraw %}
       ],
       "versioningTemplate": {% raw %}"{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"{% endraw %}
+    },
+    {
+      "description": "Manager for the knope mise tool pin -- knope-dev/knope is a monorepo that tags each crate's releases separately (e.g. knope/vX.Y.Z), so the generic \"simple mise tools\" manager above can't be used: extractVersionTemplate is what filters the mixed-prefix tags down to just knope's own",
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "knope-dev/knope",
+      "extractVersionTemplate": "^knope/v(?<version>.*)$",
+      "managerFilePatterns": [
+        {% raw %}"/mise\\..*toml(?:{%.*%})?\\.jinja/"{% endraw %}
+      ],
+      "matchStrings": [
+        "\"github:knope-dev/knope\"\\s*=\\s*\"knope/v(?<currentValue>[^\"]*)\""
+      ],
+      "versioningTemplate": "semver"
+    },
+    {
+      "description": "Manager for the knope version pin in the Knope-based release workflows",
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "knope-dev/knope",
+      "extractVersionTemplate": "^knope/v(?<version>.*)$",
+      "managerFilePatterns": [
+        {% raw %}"/(^|/)(?:{%.*%})?\\.github(?:{%.*%})?/workflows/.*knope.*\\.ya?ml(?:{%.*%})?(?:\\.jinja)?$/"{% endraw %}
+      ],
+      "matchStrings": [
+        "version:\\s*(?<currentValue>[\\d.]+)"
+      ],
+      "versioningTemplate": "semver"
     },
     {
       "description": "Manager for a Template project's own copier.yml min_copier_version pin",


### PR DESCRIPTION
knope-dev/knope tags each crate's releases separately (e.g. knope/vX.Y.Z, not a bare vX.Y.Z), so the mise.toml.jinja pin was never installable. Adds dedicated Renovate customManagers (with extractVersionTemplate to filter the monorepo's mixed-prefix tags) for both the mise pin and the version input in the Knope workflows, grouped so they bump together in one PR.