### PR TITLE
fix: correct and minimize is_template gating in renovate.json.jinja

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -203,6 +203,29 @@
       "versioningTemplate": "semver"
     },
     {
+      "description": "Manager for a Template project's own copier.yml min_copier_version pin",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)(?:{%.*%})?copier\\.yml(?:{%.*%})?(?:\\.jinja)?$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s*\\n_min_copier_version:\\s*[\"'](?<currentValue>[^\"']*)[\"']"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
+    },
+    {
+      "description": "Manager for pipx tools with options",
+      "customType": "regex",
+      "datasourceTemplate": "pypi",
+      "managerFilePatterns": [
+        "/mise\\..*toml(?:{%.*%})?\\.jinja/"
+      ],
+      "matchStrings": [
+        "\\[tools\\.\"?pipx:(?<depName>[A-Za-z0-9_.-]+)\"?\\]\\sversion = \"(?<currentValue>[^\\s]*)\""
+      ],
+      "versioningTemplate": "pep440"
+    },
+    {
       "description": "Manager for the knope version pin in the Knope-based release workflows",
       "customType": "regex",
       "datasourceTemplate": "github-releases",
@@ -217,17 +240,6 @@
       "versioningTemplate": "semver"
     },
     {
-      "description": "Manager for a Template project's own copier.yml min_copier_version pin",
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)(?:{%.*%})?copier\\.yml(?:{%.*%})?(?:\\.jinja)?$/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s*\\n_min_copier_version:\\s*[\"'](?<currentValue>[^\"']*)[\"']"
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
-    },
-    {
       "description": "Manager for pipx git-sourced tools",
       "customType": "regex",
       "managerFilePatterns": [
@@ -238,18 +250,6 @@
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"
-    },
-    {
-      "description": "Manager for pipx tools with options",
-      "customType": "regex",
-      "datasourceTemplate": "pypi",
-      "managerFilePatterns": [
-        "/mise\\..*toml(?:{%.*%})?\\.jinja/"
-      ],
-      "matchStrings": [
-        "\\[tools\\.\"?pipx:(?<depName>[A-Za-z0-9_.-]+)\"?\\]\\sversion = \"(?<currentValue>[^\\s]*)\""
-      ],
-      "versioningTemplate": "pep440"
     },
     {
       "description": "Manager for the mise install version pin in Azure Pipelines",

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -223,6 +223,30 @@
       "versioningTemplate": "semver"
     },
     {
+      "description": "Manager for a Template project's own copier.yml min_copier_version pin",
+      "customType": "regex",
+      "managerFilePatterns": [
+        {% raw %}"/(^|/)(?:{%.*%})?copier\\.yml(?:{%.*%})?(?:\\.jinja)?$/"{% endraw %}
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s*\\n_min_copier_version:\\s*[\"'](?<currentValue>[^\"']*)[\"']"
+      ],
+      "versioningTemplate": {% raw %}"{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"{% endraw %}
+    },
+    {
+      "description": "Manager for pipx tools with options",
+      "customType": "regex",
+      "datasourceTemplate": "pypi",
+      "managerFilePatterns": [
+        {% raw %}"/mise\\..*toml(?:{%.*%})?\\.jinja/"{% endraw %}
+      ],
+      "matchStrings": [
+        "\\[tools\\.\"?pipx:(?<depName>[A-Za-z0-9_.-]+)\"?\\]\\sversion = \"(?<currentValue>[^\\s]*)\""
+      ],
+      "versioningTemplate": "pep440"
+    },
+    {%- endif %}
+    {
       "description": "Manager for the knope version pin in the Knope-based release workflows",
       "customType": "regex",
       "datasourceTemplate": "github-releases",
@@ -237,21 +261,14 @@
       "versioningTemplate": "semver"
     },
     {
-      "description": "Manager for a Template project's own copier.yml min_copier_version pin",
-      "customType": "regex",
-      "managerFilePatterns": [
-        {% raw %}"/(^|/)(?:{%.*%})?copier\\.yml(?:{%.*%})?(?:\\.jinja)?$/"{% endraw %}
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s*\\n_min_copier_version:\\s*[\"'](?<currentValue>[^\"']*)[\"']"
-      ],
-      "versioningTemplate": {% raw %}"{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"{% endraw %}
-    },
-    {
       "description": "Manager for pipx git-sourced tools",
       "customType": "regex",
       "managerFilePatterns": [
+        {%- if is_template %}
         {% raw %}"/(^|/)(?:{%.*%})?mise(\\.\\w+)*\\.toml(?:{%.*%})?(\\.jinja)?$/"{% endraw %}
+        {%- else %}
+        "/(^|/)mise(\\.\\w+)*\\.toml$/"
+        {%- endif %}
       ],
       "matchStrings": [
         "\\[tools\\.\"pipx:git\\+https://github\\.com/(?<packageName>[^/]+/[^\"]+)\\.git\"\\]\\s+version = \"(?<currentValue>[^+\"]*)"
@@ -259,18 +276,7 @@
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"
     },
-    {
-      "description": "Manager for pipx tools with options",
-      "customType": "regex",
-      "datasourceTemplate": "pypi",
-      "managerFilePatterns": [
-        {% raw %}"/mise\\..*toml(?:{%.*%})?\\.jinja/"{% endraw %}
-      ],
-      "matchStrings": [
-        "\\[tools\\.\"?pipx:(?<depName>[A-Za-z0-9_.-]+)\"?\\]\\sversion = \"(?<currentValue>[^\\s]*)\""
-      ],
-      "versioningTemplate": "pep440"
-    },
+    {%- if is_template or (is_standard and using_azdo) %}
     {
       "description": "Manager for the mise install version pin in Azure Pipelines",
       "customType": "regex",
@@ -278,7 +284,11 @@
       "depNameTemplate": "jdx/mise",
       "extractVersionTemplate": "^v(?<version>.*)$",
       "managerFilePatterns": [
+        {%- if is_template %}
         {% raw %}"/(^|/)(?:{%.*%})?\\.azurepipelines(?:{%.*%})?/.+\\.ya?ml(?:{%.*%})?(?:\\.jinja)?$/"{% endraw %}
+        {%- else %}
+        "/(^|/)\\.azurepipelines/.+\\.ya?ml$/"
+        {%- endif %}
       ],
       "matchStrings": [
         "MISE_VERSION=v(?<currentValue>[^\\s]+)"
@@ -291,7 +301,11 @@
       "customType": "regex",
       "datasourceTemplate": "pypi",
       "managerFilePatterns": [
+        {%- if is_template %}
         "/mise\\..*toml(?:\\.jinja)?/"
+        {%- else %}
+        "/mise\\..*toml/"
+        {%- endif %}
       ],
       "matchStrings": [
         ".*?(--with\\s(?<depName>.+?)(\\[\\S+])*==(?<currentValue>[^\"\\s]*))"


### PR DESCRIPTION
Two customManagers were scoped to is_template-only even though their target files also exist on Standard projects, silently dropping Renovate coverage for pins those projects actually have. Separately, three managerFilePatterns shared one Jinja-aware regex between both project types; Standard's copy carried template-source-matching complexity (conditional filenames, a literal .jinja suffix) that can never match anything in a real Standard project's own repo. Split each into a plain regex for Standard, mirroring the precedent already set by the top-level azure-pipelines manager.