### PR TITLE
chore: remove dead docker/devcontainer config from renovate.json.jinja

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,23 +18,12 @@
     "description": "Copier template updates are handled via dedicated GitHub Actions Workflow/Azure DevOps pipeline",
     "enabled": false
   },
-  "devcontainer": {
-    "managerFilePatterns": [
-      "/(^|/)devcontainer\\.json(?:\\.jinja)?$/"
-    ]
-  },
   "github-actions": {
     "managerFilePatterns": [
       "/(^|/)(?:{%.*%})?\\.github(?:{%.*%})?/workflows/.+\\.ya?ml(?:{%.*%})?(?:\\.jinja)?$/"
     ]
   },
   "packageRules": [
-    {
-      "matchCategories": [
-        "docker"
-      ],
-      "pinDigests": true
-    },
     {
       "description": "Group actionlint",
       "matchPackageNames": [

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -2,8 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
   "extends": [
-    "config:recommended",
+    "config:recommended"
+    {%- if is_template or using_github %},
     "helpers:pinGitHubActionDigests"
+    {%- endif %}
   ],
   "schedule": [
     "* 0 1 * *"
@@ -25,11 +27,6 @@
     "enabled": false
   },
   {%- if is_template %}
-  "devcontainer": {
-    "managerFilePatterns": [
-      "/(^|/)devcontainer\\.json(?:\\.jinja)?$/"
-    ]
-  },
   "github-actions": {
     "managerFilePatterns": [
       {% raw %}"/(^|/)(?:{%.*%})?\\.github(?:{%.*%})?/workflows/.+\\.ya?ml(?:{%.*%})?(?:\\.jinja)?$/"{% endraw %}
@@ -37,12 +34,6 @@
   },
   {%- endif %}
   "packageRules": [
-    {
-      "matchCategories": [
-        "docker"
-      ],
-      "pinDigests": true
-    },
     {
       "description": "Group actionlint",
       "matchPackageNames": [


### PR DESCRIPTION
Neither Dockerfile/docker-compose nor devcontainer.json exist anywhere in this template, so the docker packageRule and devcontainer manager never matched anything. Also gate helpers:pinGitHubActionDigests out of extends for Standard+Azure DevOps projects, which have no .github/workflows for it to ever act on.