### PR TITLE
fix: current_knope_version's _copier_operation guard never evaluates

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -396,10 +396,10 @@ zensical_repo:
 current_knope_version:
   type: str
   default: |-
-    {%- if _copier_operation == 'update' -%}
-      {%- set _version_file = ('git show HEAD:.config/knope-current-version.json' | shell()) | from_json -%}
-      {{- _version_file.version -}}
-    {%- endif %}
+    {%- set _version_file_raw = ('git show HEAD:.config/knope-current-version.json 2>&1' | shell()) -%}
+    {%- if '"version"' in _version_file_raw -%}
+      {{- (_version_file_raw | from_json).version -}}
+    {%- endif -%}
   when: false
 
 current_knope_version_is_pre_1:

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -409,10 +409,10 @@ zensical_repo:
 current_knope_version:
   type: str
   default: |-
-    {%- if _copier_operation == 'update' -%}
-      {%- set _version_file = ('git show HEAD:.config/knope-current-version.json' | shell()) | from_json -%}
-      {{- _version_file.version -}}
-    {%- endif %}
+    {%- set _version_file_raw = ('git show HEAD:.config/knope-current-version.json 2>&1' | shell()) -%}
+    {%- if '"version"' in _version_file_raw -%}
+      {{- (_version_file_raw | from_json).version -}}
+    {%- endif -%}
   when: false
 
 current_knope_version_is_pre_1:


### PR DESCRIPTION
_copier_operation isn't injected into question-rendering context at all (only task-command and exclude-pattern rendering) -- so the "graduating to 1.0.0" nudge message never actually fires. Replace it with a success-marker check on the shell() output, matching this file's other such checks. Also drop the leftover using_github gate: knope-current-version.json is unconditional on both platforms now that the Azure DevOps release flow uses Knope too, so the AzDO-specific text already in _message_after_update was unreachable.