### PR TITLE
feat: add a monthly link-checking workflow/pipeline

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -534,6 +534,19 @@ _tasks:
         true
       {%- endif %}
 
+  # Creates Azure Pipeline for link checking
+  - command: >-
+      az pipelines create
+      --name "[{{ repo_name }}] link-check"
+      --repository {{ repo_name }}
+      --repository-type tfsgit
+      --branch main
+      --yml-path .azurepipelines/maint-auto-link_check.yml
+      --skip-first-run true
+      --org https://dev.azure.com/{{ azdo_org }}/
+      --project "{{ azdo_project }}"
+    when: *when_copy_set_repo_settings_azdo
+
   # Creates Azure Pipeline for renovate
   - command: >-
       az pipelines create

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -547,6 +547,19 @@ _tasks:
         true
       {%- endif %}
 
+  # Creates Azure Pipeline for link checking
+  - command: >-
+      az pipelines create
+      --name "[{{ repo_name }}] link-check"
+      --repository {{ repo_name }}
+      --repository-type tfsgit
+      --branch main
+      --yml-path .azurepipelines/maint-auto-link_check.yml
+      --skip-first-run true
+      --org https://dev.azure.com/{{ azdo_org }}/
+      --project "{{ azdo_project }}"
+    when: *when_copy_set_repo_settings_azdo
+
   # Creates Azure Pipeline for renovate
   - command: >-
       az pipelines create

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/maint-auto-link_check.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/maint-auto-link_check.yml
@@ -1,0 +1,42 @@
+name: $(BuildId)
+
+trigger:
+  branches:
+    exclude:
+      - "*"
+
+schedules:
+  # Offset from the other Monday jobs (copier-update-check, renovate) to avoid runner
+  # contention.
+  - cron: 0 18 * * 1
+    displayName: Check for Broken Links Every Monday at 6pm UTC
+    branches:
+      include:
+        - main
+
+variables:
+  CI: true
+  MISE_ENV: ci
+
+pool:
+  vmImage: ubuntu-latest
+
+stages:
+  - stage: link_check
+    displayName: Link Check
+    jobs:
+      - job: link_check
+        timeoutInMinutes: 15
+        displayName: Link Check
+        steps:
+          - checkout: self
+          - bash: |
+              # renovate: datasource=github-releases depName=jdx/mise
+              curl https://mise.run | MISE_VERSION=v2026.8.10 MISE_INSTALL_SKIP_IF_EXISTS=1 sh
+              echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
+              echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
+            displayName: Install Mise
+          - bash: mise install
+            displayName: Run 'mise install'
+          - bash: mise x -- lychee --no-progress -c .config/lychee.toml .
+            displayName: Check for Broken Links

--- a/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-link_check.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-link_check.yml
@@ -1,0 +1,29 @@
+name: "[Maint] Link Check"
+
+on:
+  schedule:
+    - cron: 0 18 * * 1 # Every Monday at 6pm UTC (offset from the other Monday jobs)
+  workflow_dispatch:
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        with:
+          experimental: true
+      - name: Check for Broken Links
+        run: mise x -- lychee --no-progress -c .config/lychee.toml .
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c # v1


### PR DESCRIPTION
Runs lychee against the whole repo on a schedule, catching link rot that only prek's pre-commit hook would otherwise catch -- and only then for files actually touched in a commit.