### PR TITLE
feat: require PR titles to be a Conventional Commit

### DIFF
--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/pr_validation.yml.jinja
@@ -67,6 +67,19 @@ stages:
             displayName: Install Mise
           - bash: mise install
             displayName: Run 'mise install'
+          - pwsh: |
+              $GetSplat = @{
+                ContentType = "application/json"
+                Headers = @{
+                  Authorization = "Basic $([Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("user:$env:SYSTEM_ACCESSTOKEN")))"
+                }
+                Uri = "$(System.CollectionUri)/$(System.TeamProject)/_apis/git/repositories/$(Build.Repository.Name)/pullrequests/$(System.PullRequest.PullRequestId)?api-version=7.0"
+              }
+              $PRTitle = (Invoke-RestMethod @GetSplat).title
+              $PRTitle | mise x -- committed --config .config/committed.toml --commit-file -
+            displayName: Check PR Title is a Conventional Commit
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           - bash: |
               # Scopes the lint run to files actually changed on this PR, matching
               # GitHub's counterpart (which runs the same git diff) -- identical PR

--- a/template/{% if using_github %}.github{% endif %}/workflows/test-pr_validation.yml.jinja
+++ b/template/{% if using_github %}.github{% endif %}/workflows/test-pr_validation.yml.jinja
@@ -2,6 +2,9 @@ name: "[Test] PR Validation"
 
 on:
   pull_request:
+    # Explicit -- the implicit default (opened, synchronize, reopened) omits `edited`,
+    # so a title-only edit wouldn't otherwise re-run the PR-title check below.
+    types: [opened, edited, synchronize, reopened]
 
 concurrency:
   group: {% raw %}${{ github.head_ref || github.run_id }}{% endraw %}
@@ -20,6 +23,10 @@ jobs:
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
         with:
           experimental: true
+      - name: Check PR Title is a Conventional Commit
+        env:
+          PR_TITLE: {% raw %}${{ github.event.pull_request.title }}{% endraw %}
+        run: echo "$PR_TITLE" | mise x -- committed --config .config/committed.toml --commit-file -
       - name: Run Prek Tests
         env:
           BASE_REF: {% raw %}${{ github.base_ref }}{% endraw %}


### PR DESCRIPTION
Squash-merging uses the PR title as the resulting commit message on main -- Knope scans that history to compute version bumps, so a non-conventional title landing there would pollute it. Reuses the existing committed config, since a PR title needs the same shape as a commit message.