### PR TITLE
feat: track post-copy setup items as a GitHub Issue or printed checklist

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -409,6 +409,18 @@ current_knope_version_is_pre_1:
       true
     {%- endif %}
   when: false
+
+setup_checklist:
+  type: str
+  default: |-
+    - [ ] Add more badges to the top of README.md, or remove that section.
+    - [ ] Replace docs/images/readme-logo.png with your own logo, or remove that section from README.md.
+    - [ ] Replace docs/images/readme-screenshot.png with a real screenshot of your project, or remove that section from README.md.
+    - [ ] Set required secrets/pipeline variables -- run `mise run provision-secrets` or see docs/token_permissions.md.
+    {%- if is_template and integration_test_scheduled and using_github %}
+    - [ ] Edit the AZDO_INTEGRATION_TEST_ORG/AZDO_INTEGRATION_TEST_PROJECT placeholders in .github/workflows/test-auto-integration_test.yml with your real Azure DevOps org/project.
+    {%- endif %}
+  when: false
 ## End Post-Question Computed Values
 
 ## Start Locked Values
@@ -750,10 +762,31 @@ _tasks:
   # since a private repo's issues are already restricted to invited collaborators.
   - command: gh api repos/{{ github_repo_owner }}/{{ repo_name }}/private-vulnerability-reporting -X PUT
     when: *when_copy_public_github
+
+  # Opens the setup checklist as a GitHub Issue
+  - command:
+      - gh
+      - issue
+      - create
+      - --repo
+      - "{{ github_repo_owner }}/{{ repo_name }}"
+      - --title
+      - "Template Setup Checklist"
+      - --body
+      - "{{ setup_checklist }}"
+    when: |-
+      {%- if _copier_operation == 'copy' and using_github and repo_setup_actions != 'None' -%}
+        true
+      {%- endif %}
 ## End Tasks
 
 ## Start Messages
 _message_after_copy: |-
+  {%- if using_azdo or (using_github and repo_setup_actions == 'None') %}
+
+  Setup checklist:
+  {{ setup_checklist }}
+  {% endif -%}
   {%- if using_github -%}
     Repo settings (labels, merge options, branch protection) are not being applied automatically. See the 'Manual Repo Settings' page in documentation for how to replicate them by hand, or install the Settings GitHub App (https://github.com/apps/settings) and it will pick up the already-generated .github/settings.yml on its own.
 

--- a/template/{% if agent_instructions %}AGENTS.md{% endif %}.jinja
+++ b/template/{% if agent_instructions %}AGENTS.md{% endif %}.jinja
@@ -26,6 +26,13 @@ via `INVALID_ANSWER_MATRIX`), `test_answer_matrix_coverage.py` (audits
 `answer_matrix.py` itself against the real question set). **Update
 `answer_matrix.py` whenever a Copier question is added, removed, or renamed,
 or a new `validator:` constraint is added.**
+
+## Setup checklist
+
+`setup_checklist` in `copier.yml.jinja` (opened as a GitHub Issue, or printed, on
+`copier copy`) is the single source of truth for what a new project's owner needs to
+manually finish. **Update its default list whenever a new template feature requires
+the end user to manually configure, replace, or complete something after copying.**
 {%- endif %}
 
 ## Renovate `schedule` cron syntax is not standard cron

--- a/template/{% if is_standard %}README.md{% endif %}.jinja
+++ b/template/{% if is_standard %}README.md{% endif %}.jinja
@@ -1,13 +1,11 @@
-<!-- TODO: Add real badges here, e.g. from https://shields.io, or remove this section. -->
 <p align="center">
-  <img alt="Placeholder badge" src="https://img.shields.io/badge/status-placeholder-lightgrey">
+  <a href="https://conventionalcommits.org"><img alt="Conventional Commits" src="https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white"></a>
   {%- if is_public %}
   <a href="#contributors"><img alt="All Contributors" src="https://img.shields.io/github/all-contributors/{{ github_repo_owner }}/{{ repo_name }}?color=ee8449&style=flat-square"></a>
   {%- endif %}
 </p>
 
 <div align="center">
-  <!-- TODO: Replace docs/images/readme-logo.png with your own logo, or remove this section. -->
   <img src="docs/images/readme-logo.png" alt="Logo" width="80" height="80">
 
   <h3 align="center">{{ project_name }}</h3>
@@ -17,7 +15,6 @@
   </p>
 </div>
 
-<!-- TODO: Replace docs/images/readme-screenshot.png with a real screenshot of your project, or remove this section. -->
 <p align="center">
   <img src="docs/images/readme-screenshot.png" alt="Screenshot">
 </p>

--- a/template/{% if is_template %}README.md{% endif %}.jinja
+++ b/template/{% if is_template %}README.md{% endif %}.jinja
@@ -1,13 +1,11 @@
-<!-- TODO: Add real badges here, e.g. from https://shields.io, or remove this section. -->
 <p align="center">
-  <img alt="Placeholder badge" src="https://img.shields.io/badge/status-placeholder-lightgrey">
+  <a href="https://conventionalcommits.org"><img alt="Conventional Commits" src="https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white"></a>
   {%- if is_public %}
   <a href="#contributors"><img alt="All Contributors" src="https://img.shields.io/github/all-contributors/{{ github_repo_owner }}/{{ repo_name }}?color=ee8449&style=flat-square"></a>
   {%- endif %}
 </p>
 
 <div align="center">
-  <!-- TODO: Replace docs/images/readme-logo.png with your own logo, or remove this section. -->
   <img src="docs/images/readme-logo.png" alt="Logo" width="80" height="80">
 
   <h3 align="center">{{ project_name }}</h3>
@@ -17,7 +15,6 @@
   </p>
 </div>
 
-<!-- TODO: Replace docs/images/readme-screenshot.png with a real screenshot of your project, or remove this section. -->
 <p align="center">
   <img src="docs/images/readme-screenshot.png" alt="Screenshot">
 </p>

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -422,6 +422,18 @@ current_knope_version_is_pre_1:
       true
     {%- endif %}
   when: false
+
+setup_checklist:
+  type: str
+  default: |-
+    - [ ] Add more badges to the top of README.md, or remove that section.
+    - [ ] Replace docs/images/readme-logo.png with your own logo, or remove that section from README.md.
+    - [ ] Replace docs/images/readme-screenshot.png with a real screenshot of your project, or remove that section from README.md.
+    - [ ] Set required secrets/pipeline variables -- run `mise run provision-secrets` or see docs/token_permissions.md.
+    {%- if is_template and integration_test_scheduled and using_github %}
+    - [ ] Edit the AZDO_INTEGRATION_TEST_ORG/AZDO_INTEGRATION_TEST_PROJECT placeholders in .github/workflows/test-auto-integration_test.yml with your real Azure DevOps org/project.
+    {%- endif %}
+  when: false
 ## End Post-Question Computed Values
 
 ## Start Locked Values
@@ -763,10 +775,31 @@ _tasks:
   # since a private repo's issues are already restricted to invited collaborators.
   - command: gh api repos/{{ github_repo_owner }}/{{ repo_name }}/private-vulnerability-reporting -X PUT
     when: *when_copy_public_github
+
+  # Opens the setup checklist as a GitHub Issue
+  - command:
+      - gh
+      - issue
+      - create
+      - --repo
+      - "{{ github_repo_owner }}/{{ repo_name }}"
+      - --title
+      - "Template Setup Checklist"
+      - --body
+      - "{{ setup_checklist }}"
+    when: |-
+      {%- if _copier_operation == 'copy' and using_github and repo_setup_actions != 'None' -%}
+        true
+      {%- endif %}
 ## End Tasks
 
 ## Start Messages
 _message_after_copy: |-
+  {%- if using_azdo or (using_github and repo_setup_actions == 'None') %}
+
+  Setup checklist:
+  {{ setup_checklist }}
+  {% endif -%}
   {%- if using_github -%}
     Repo settings (labels, merge options, branch protection) are not being applied automatically. See the 'Manual Repo Settings' page in documentation for how to replicate them by hand, or install the Settings GitHub App (https://github.com/apps/settings) and it will pick up the already-generated .github/settings.yml on its own.
 


### PR DESCRIPTION
Replaces 3 inline README <!-- TODO --> comments (easy to overlook, easy to forget cleaning up) with a proper one-time checklist, sourced from one structured setup_checklist value so the two destinations can't drift: a GitHub Issue with checkboxes when a repo actually gets created, a printed message otherwise (Azure DevOps, or GitHub with repo_setup_actions: None). Gated on _copier_operation == 'copy', so it's never regenerated on update. A broader pass across the template turned up one more real item worth tracking (the AzDO integration-test placeholder env vars in test-auto-integration_test.yml), folded in alongside the README placeholders and a pointer to the existing guided secrets setup.

Also swaps the badges row's fake placeholder badge for a real Conventional Commits one, since every generated project actually enforces that.