### PR TITLE
feat: cache CI tool installs and migrate off knope-dev/action

### DIFF
--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/docs-auto-zensical.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/docs-auto-zensical.yml.jinja
@@ -55,8 +55,24 @@ stages:
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
             displayName: Install Mise
+          - task: Cache@2
+            inputs:
+              key: 'mise | "$(Agent.OS)" | mise.toml | mise.ci.toml'
+              restoreKeys: |
+                mise | "$(Agent.OS)"
+              path: $(HOME)/.local/share/mise
+            displayName: Cache Mise Tools
           - bash: mise install
             displayName: Run 'mise install'
+          - bash: echo "##vso[task.setvariable variable=CACHE_ID]$(date --utc '+%V')"
+            displayName: Compute Cache ID
+          - task: Cache@2
+            inputs:
+              key: 'zensical | "$(CACHE_ID)"'
+              restoreKeys: |
+                zensical
+              path: $(HOME)/.cache
+            displayName: Cache Zensical Build
           - bash: |
               zensical build
               git add --all

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/maint-auto-copier_update_check.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/maint-auto-copier_update_check.yml
@@ -52,6 +52,13 @@ stages:
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
             displayName: Install Mise
+          - task: Cache@2
+            inputs:
+              key: 'mise | "$(Agent.OS)" | mise.toml | mise.ci.toml'
+              restoreKeys: |
+                mise | "$(Agent.OS)"
+              path: $(HOME)/.local/share/mise
+            displayName: Cache Mise Tools
           - bash: mise install
             displayName: Run 'mise install'
           - pwsh: |

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/maint-auto-renovate.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/maint-auto-renovate.yml.jinja
@@ -54,6 +54,13 @@ stages:
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
             displayName: Install Mise
+          - task: Cache@2
+            inputs:
+              key: 'mise | "$(Agent.OS)" | mise.toml | mise.ci.toml'
+              restoreKeys: |
+                mise | "$(Agent.OS)"
+              path: $(HOME)/.local/share/mise
+            displayName: Cache Mise Tools
           - bash: mise install
             displayName: Run 'mise install'
           - bash: mise x -- renovate "{{ azdo_project }}/{{ repo_name }}"

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/release-auto-release.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/release-auto-release.yml
@@ -33,6 +33,13 @@ stages:
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
             displayName: Install Mise
+          - task: Cache@2
+            inputs:
+              key: 'mise | "$(Agent.OS)" | mise.toml | mise.ci.toml'
+              restoreKeys: |
+                mise | "$(Agent.OS)"
+              path: $(HOME)/.local/share/mise
+            displayName: Cache Mise Tools
           - bash: mise install
             displayName: Run 'mise install'
           - bash: az extension add --name azure-devops

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/release-manual-create_prerelease.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/release-manual-create_prerelease.yml
@@ -43,6 +43,13 @@ stages:
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
             displayName: Install Mise
+          - task: Cache@2
+            inputs:
+              key: 'mise | "$(Agent.OS)" | mise.toml | mise.ci.toml'
+              restoreKeys: |
+                mise | "$(Agent.OS)"
+              path: $(HOME)/.local/share/mise
+            displayName: Cache Mise Tools
           - bash: mise install
             displayName: Run 'mise install'
           - pwsh: |

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/test-auto-pr_validation.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/test-auto-pr_validation.yml.jinja
@@ -65,6 +65,13 @@ stages:
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
             displayName: Install Mise
+          - task: Cache@2
+            inputs:
+              key: 'mise | "$(Agent.OS)" | mise.toml | mise.ci.toml'
+              restoreKeys: |
+                mise | "$(Agent.OS)"
+              path: $(HOME)/.local/share/mise
+            displayName: Cache Mise Tools
           - bash: mise install
             displayName: Run 'mise install'
           - pwsh: |

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/{% if is_template and integration_test_scheduled %}test-auto-integration_test.yml{% endif %}
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/{% if is_template and integration_test_scheduled %}test-auto-integration_test.yml{% endif %}
@@ -49,9 +49,23 @@ stages:
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/bin"
               echo "##vso[task.prependpath]$(HOME)/.local/share/mise/shims"
             displayName: Install Mise
+          - task: Cache@2
+            inputs:
+              key: 'mise | "$(Agent.OS)" | mise.toml | mise.ci.toml'
+              restoreKeys: |
+                mise | "$(Agent.OS)"
+              path: $(HOME)/.local/share/mise
+            displayName: Cache Mise Tools
           - bash: mise install
             displayName: Run 'mise install'
-          - bash: az extension add --name azure-devops --only-show-errors
+          - task: Cache@2
+            inputs:
+              key: azure-devops-cli-ext-$(Agent.OS)
+              path: $(HOME)/.azure/cliextensions
+            displayName: Cache Azure DevOps CLI Extension
+          - bash: |
+              az extension list -o tsv --query "[?name=='azure-devops'].name" | grep -q azure-devops || \
+                az extension add --name azure-devops --only-show-errors
             displayName: Install Azure DevOps CLI Extension
           - bash: |
               # Same script `mise run integration-test-azdo` runs locally (there,

--- a/template/{% if using_github %}.github{% endif %}/workflows/release-auto-prepare_release_pr.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/release-auto-prepare_release_pr.yml
@@ -21,11 +21,11 @@ jobs:
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email github-actions@github.com
-      - uses: knope-dev/action@19617851f9f13ab2f27a05989c55efb18aca3675 # v2.1.2
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
         with:
-          version: 0.23.0
+          experimental: true
       - name: Prepare Release PR
-        run: knope autoupdate-knope-pr --verbose
+        run: mise x -- knope autoupdate-knope-pr --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true

--- a/template/{% if using_github %}.github{% endif %}/workflows/release-auto-publish_release.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/release-auto-publish_release.yml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - uses: knope-dev/action@19617851f9f13ab2f27a05989c55efb18aca3675 # v2.1.2
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
         with:
-          version: 0.23.0
+          experimental: true
       - name: Publish Release
-        run: knope release-on-knope-pr-merge --verbose
+        run: mise x -- knope release-on-knope-pr-merge --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/template/{% if using_github %}.github{% endif %}/workflows/release-manual-create_prerelease.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/release-manual-create_prerelease.yml
@@ -34,11 +34,11 @@ jobs:
             Write-Host "::error::This commit is already tagged as $duplicate -- push a new commit before cutting another $($env:LABEL) prerelease."
             exit 1
           }
-      - uses: knope-dev/action@19617851f9f13ab2f27a05989c55efb18aca3675 # v2.1.2
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
         with:
-          version: 0.23.0
+          experimental: true
       - name: Create Prerelease
-        run: knope create-prerelease-via-knope --prerelease-label ${{ inputs.label }} --verbose
+        run: mise x -- knope create-prerelease-via-knope --prerelease-label ${{ inputs.label }} --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Capture Version

--- a/template/{% if using_github %}.github{% endif %}/workflows/{% if is_template and integration_test_scheduled %}test-auto-integration_test.yml{% endif %}
+++ b/template/{% if using_github %}.github{% endif %}/workflows/{% if is_template and integration_test_scheduled %}test-auto-integration_test.yml{% endif %}
@@ -67,8 +67,14 @@ jobs:
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
         with:
           experimental: true
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          key: azure-devops-cli-ext-${{ runner.os }}
+          path: ~/.azure/cliextensions
       - name: Install Azure DevOps CLI Extension
-        run: az extension add --name azure-devops --only-show-errors
+        run: |
+          az extension list -o tsv --query "[?name=='azure-devops'].name" | grep -q azure-devops || \
+            az extension add --name azure-devops --only-show-errors
       - name: Create, Verify, and Clean Up Test Repo
         # Same script `mise run integration-test-azdo` runs locally (there, --cleanup
         # is left off so the repo stays around for inspection) -- see

--- a/template/{% if using_github %}.github{% endif %}/workflows/{% if zensical_repo %}docs-auto-mkdocs.yml{% endif %}
+++ b/template/{% if using_github %}.github{% endif %}/workflows/{% if zensical_repo %}docs-auto-mkdocs.yml{% endif %}
@@ -34,6 +34,13 @@ jobs:
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
         with:
           experimental: true
+      - run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          key: zensical-${{ env.cache_id }}
+          path: ~/.cache
+          restore-keys: |
+            zensical-
       - run: zensical build
       - name: Create Pull Request
         id: cpr


### PR DESCRIPTION
Adds Cache@2/actions/cache steps for Mise's own tool cache, the Azure DevOps CLI extension, and Zensical's build cache (keyed by ISO week) to the pipelines/workflows that run frequently enough for caching to pay off -- deliberately left off the monthly link-check job, where caches would just get evicted between runs. Also drops the now-redundant knope-dev/action GitHub Action (last released for Knope 0.23) in favor of installing Knope through Mise like every other tool, since Mise's own action and cache already handle it.