### PR TITLE
fix: drop unneeded experimental flag from jdx/mise-action

### DIFF
--- a/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-link_check.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-link_check.yml
@@ -15,8 +15,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
-        with:
-          experimental: true
       - name: Check for Broken Links
         run: mise x -- lychee --no-progress -c .config/lychee.toml .
   workflow-keepalive:

--- a/template/{% if using_github %}.github{% endif %}/workflows/release-auto-prepare_release_pr.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/release-auto-prepare_release_pr.yml
@@ -22,8 +22,6 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email github-actions@github.com
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
-        with:
-          experimental: true
       - name: Prepare Release PR
         run: mise x -- knope autoupdate-knope-pr --verbose
         env:

--- a/template/{% if using_github %}.github{% endif %}/workflows/release-auto-publish_release.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/release-auto-publish_release.yml
@@ -18,8 +18,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
-        with:
-          experimental: true
       - name: Publish Release
         run: mise x -- knope release-on-knope-pr-merge --verbose
         env:

--- a/template/{% if using_github %}.github{% endif %}/workflows/release-manual-create_prerelease.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/release-manual-create_prerelease.yml
@@ -35,8 +35,6 @@ jobs:
             exit 1
           }
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
-        with:
-          experimental: true
       - name: Create Prerelease
         run: mise x -- knope create-prerelease-via-knope --prerelease-label ${{ inputs.label }} --verbose
         env:

--- a/template/{% if using_github %}.github{% endif %}/workflows/test-auto-pr_validation.yml.jinja
+++ b/template/{% if using_github %}.github{% endif %}/workflows/test-auto-pr_validation.yml.jinja
@@ -21,8 +21,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
-        with:
-          experimental: true
       - name: Check PR Title is a Conventional Commit
         env:
           PR_TITLE: {% raw %}${{ github.event.pull_request.title }}{% endraw %}

--- a/template/{% if using_github %}.github{% endif %}/workflows/{% if is_template and integration_test_scheduled %}test-auto-integration_test.yml{% endif %}
+++ b/template/{% if using_github %}.github{% endif %}/workflows/{% if is_template and integration_test_scheduled %}test-auto-integration_test.yml{% endif %}
@@ -24,8 +24,6 @@ jobs:
           secrets: |
             INTEGRATION_TEST_PAT=${{ secrets.INTEGRATION_TEST_PAT }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
-        with:
-          experimental: true
       - name: Create, Verify, and Clean Up Test Repo
         # Same script `mise run integration-test-gh` runs locally (there, --cleanup is
         # left off so the repo stays around for inspection) -- see
@@ -65,8 +63,6 @@ jobs:
           secrets: |
             AZURE_DEVOPS_EXT_PAT=${{ secrets.AZURE_DEVOPS_EXT_PAT }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
-        with:
-          experimental: true
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           key: azure-devops-cli-ext-${{ runner.os }}

--- a/template/{% if using_github %}.github{% endif %}/workflows/{% if zensical_ghpages %}docs-auto-zensical.yml{% endif %}
+++ b/template/{% if using_github %}.github{% endif %}/workflows/{% if zensical_ghpages %}docs-auto-zensical.yml{% endif %}
@@ -35,8 +35,6 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
-        with:
-          experimental: true
       - run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:

--- a/template/{% if using_github %}.github{% endif %}/workflows/{% if zensical_repo %}docs-auto-mkdocs.yml{% endif %}
+++ b/template/{% if using_github %}.github{% endif %}/workflows/{% if zensical_repo %}docs-auto-mkdocs.yml{% endif %}
@@ -32,8 +32,6 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
-        with:
-          experimental: true
       - run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:


### PR DESCRIPTION
experimental: true sets MISE_EXPERIMENTAL=1, a leftover from when this repo first adopted mise-action (commit aa2fa33, June 2025) and pipx-backed tools required it. Verified empirically against this repo's own mise.toml with the currently pinned mise version: pipx-backed tools (copier, pytest, zensical) and the task `usage` field both resolve and run fine with the variable unset, so the flag no longer does anything.