### PR TITLE
refactor: unify mise.ci.toml as one shared, opt-in CI extras file

### DIFF
--- a/template/mise.ci.toml.jinja
+++ b/template/mise.ci.toml.jinja
@@ -1,9 +1,15 @@
 [tools]
 {#- renovate: datasource=pypi depName=apprise versioning=pep440 #}
 "pipx:apprise" = "1.12.0"
-# Used by the Renovate pipeline (.azurepipelines/maint-auto-renovate.yml.jinja) -- no other AzDO
-# pipeline needs Node.js or Renovate itself.
+{%- if using_azdo %}
 {#- renovate: datasource=node-version depName=node versioning=node #}
 node = "24.19.0"
 {#- renovate: datasource=npm depName=renovate #}
 "npm:renovate" = "44.39.3"
+{%- endif %}
+{%- if using_github and zensical_ghpages %}
+
+[tools."pipx:git+https://github.com/squidfunk/mike.git"]
+version = "2.2.0+zensical-0.1.0"
+uvx_args = "--with zensical==0.0.53"
+{%- endif %}

--- a/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-copier_update_check.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-copier_update_check.yml
@@ -5,6 +5,9 @@ on:
     - cron: 0 17 * * 1 # Every Monday at 5pm UTC
   workflow_dispatch:
 
+env:
+  MISE_ENV: ci
+
 jobs:
   copier-check-update:
     runs-on: ubuntu-latest
@@ -26,17 +29,16 @@ jobs:
         uses: natescherer/copier-action@b1ee418e5ee2e4334fc26094b9e84be3b93112ac # v0
         with:
           subcommand: check-update
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
       - name: Notify if Update is Available
         if: steps.copier.outputs.check-update_update_available == 'true'
-        uses: cstuder/apprise-ga@bf5b5984a6017b3aea5c277da593839a0cdd2368 # v3.1.0
-        with:
-          title: ${{ github.repository }} Template Update Available
-          message: |
-            Repository ${{ github.repository }} has a new template update available.
-
-            Current version is ${{ steps.copier.outputs.check-update_current_version }}, latest version is ${{ steps.copier.outputs.check-update_latest_version }}.
         env:
           APPRISE_URL: ${{ secrets.APPRISE_URL }}
+        run: |
+          mise x -- apprise -i html \
+            -t "${{ github.repository }} Template Update Available" \
+            -b "Repository ${{ github.repository }} has a new template update available.<br><br>Current version is ${{ steps.copier.outputs.check-update_current_version }}, latest version is ${{ steps.copier.outputs.check-update_latest_version }}." \
+            "$APPRISE_URL"
   workflow-keepalive:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest

--- a/template/{% if using_github and zensical_ghpages %}mise.ci.toml{% endif %}.jinja
+++ b/template/{% if using_github and zensical_ghpages %}mise.ci.toml{% endif %}.jinja
@@ -1,3 +1,0 @@
-[tools."pipx:git+https://github.com/squidfunk/mike.git"]
-version = "2.2.0+zensical-0.1.0"
-uvx_args = "--with zensical==0.0.53"


### PR DESCRIPTION
mise.ci.toml previously existed as two separate, differently-gated files -- one for Azure DevOps (node/renovate), one for GitHub+GitHub Pages (mike) -- with no shared concept between them. Merges them into one file that always renders, gating each platform's own additions inside it instead of in the filename, and adds the Apprise CLI that replaces cstuder/apprise-ga (a Linux-only Docker action) for the GitHub copier-update-check notification, mirroring how Azure DevOps already sends the same notification. Every pipeline/workflow that needs any of this already opts in via MISE_ENV=ci; the GitHub copier-update-check workflow now does too.