### PR TITLE
fix: inline gh-workflow-keepalive to fix Windows compatibility

### DIFF
--- a/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-copier_update_check.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-copier_update_check.yml
@@ -46,4 +46,19 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: liskin/gh-workflow-keepalive@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c # v1
+      # Re-enables this workflow if GitHub disabled it for inactivity. Inlined from
+      # liskin/gh-workflow-keepalive, whose one step is pinned to `shell: sh` --
+      # unsupported on Windows runners, unlike bash, which is available there via Git
+      # for Windows.
+      - name: Re-enable Workflow
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          case "${GITHUB_WORKFLOW_REF:?}" in
+            "${GITHUB_REPOSITORY:?}"/.github/workflows/*.y*ml@*) ;;
+            *) false ;;
+          esac
+          workflow="${GITHUB_WORKFLOW_REF%%@*}"
+          workflow="${workflow#"$GITHUB_REPOSITORY"/.github/workflows/}"
+          gh api -X PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/enable"

--- a/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-link_check.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-link_check.yml
@@ -24,4 +24,19 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: liskin/gh-workflow-keepalive@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c # v1
+      # Re-enables this workflow if GitHub disabled it for inactivity. Inlined from
+      # liskin/gh-workflow-keepalive, whose one step is pinned to `shell: sh` --
+      # unsupported on Windows runners, unlike bash, which is available there via Git
+      # for Windows.
+      - name: Re-enable Workflow
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          case "${GITHUB_WORKFLOW_REF:?}" in
+            "${GITHUB_REPOSITORY:?}"/.github/workflows/*.y*ml@*) ;;
+            *) false ;;
+          esac
+          workflow="${GITHUB_WORKFLOW_REF%%@*}"
+          workflow="${workflow#"$GITHUB_REPOSITORY"/.github/workflows/}"
+          gh api -X PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/enable"

--- a/template/{% if using_github %}.github{% endif %}/workflows/{% if is_template and integration_test_scheduled %}test-auto-integration_test.yml{% endif %}
+++ b/template/{% if using_github %}.github{% endif %}/workflows/{% if is_template and integration_test_scheduled %}test-auto-integration_test.yml{% endif %}
@@ -96,4 +96,19 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: liskin/gh-workflow-keepalive@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c # v1
+      # Re-enables this workflow if GitHub disabled it for inactivity. Inlined from
+      # liskin/gh-workflow-keepalive, whose one step is pinned to `shell: sh` --
+      # unsupported on Windows runners, unlike bash, which is available there via Git
+      # for Windows.
+      - name: Re-enable Workflow
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          case "${GITHUB_WORKFLOW_REF:?}" in
+            "${GITHUB_REPOSITORY:?}"/.github/workflows/*.y*ml@*) ;;
+            *) false ;;
+          esac
+          workflow="${GITHUB_WORKFLOW_REF%%@*}"
+          workflow="${workflow#"$GITHUB_REPOSITORY"/.github/workflows/}"
+          gh api -X PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/enable"


### PR DESCRIPTION
liskin/gh-workflow-keepalive's one step is pinned to shell: sh, which Windows runners don't offer as a shell option at all -- the step would error before running. Inlines its exact logic (re-enabling the workflow via `gh api` after GitHub disables it for inactivity) as a plain run step under shell: bash instead, which Windows runners do support via Git for Windows. Also fixes a pre-existing shellcheck finding (SC2295) in the source: the nested $GITHUB_REPOSITORY expansion inside the prefix-strip pattern needs its own quoting so a repository name with glob characters can't change the match.