### PR TITLE
fix: standardize GitHub workflows on Bash for runner portability

### DIFF
--- a/template/mise.ci.toml.jinja
+++ b/template/mise.ci.toml.jinja
@@ -1,6 +1,12 @@
 [tools]
 {#- renovate: datasource=pypi depName=apprise versioning=pep440 #}
 "pipx:apprise" = "1.12.0"
+{%- if using_github %}
+{#- Used by release-manual-create_prerelease.yml's Capture Version step. GitHub-hosted
+   runners ship jq by default, but self-hosted ones aren't guaranteed to. #}
+{#- renovate: datasource=github-releases depName=jqlang/jq #}
+jq = "1.8.2"
+{%- endif %}
 {%- if using_azdo %}
 {#- renovate: datasource=node-version depName=node versioning=node #}
 node = "24.19.0"

--- a/template/{% if using_github %}.github{% endif %}/actions/require-secrets/action.yml
+++ b/template/{% if using_github %}.github{% endif %}/actions/require-secrets/action.yml
@@ -7,17 +7,17 @@ inputs:
 runs:
   using: composite
   steps:
-    - shell: pwsh
+    - shell: bash
       run: |-
-        $Pairs = "${{ inputs.secrets }}" -split "`n" | Where-Object { $_ -ne "" }
-        $MissingSecret = $False
-        foreach ($Pair in $Pairs) {
-          $Name, $Value = $Pair -split "=", 2
-          if ([string]::IsNullOrEmpty($Value)) {
-            Write-Host -Object "::error title=Missing Secret::Required Actions secret '$Name' is not set! Please add it in repo/org settings."
-            $MissingSecret = $True
-          }
-        }
-        if ($MissingSecret) {
-          throw "Erroring as one or more required secrets are missing!"
-        }
+        missing=0
+        while IFS='=' read -r name value; do
+          [ -z "$name" ] && continue
+          if [ -z "$value" ]; then
+            echo "::error title=Missing Secret::Required Actions secret '$name' is not set! Please add it in repo/org settings."
+            missing=1
+          fi
+        done <<< "${{ inputs.secrets }}"
+        if [ "$missing" -eq 1 ]; then
+          echo "Erroring as one or more required secrets are missing!" >&2
+          exit 1
+        fi

--- a/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-copier_update_check.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-copier_update_check.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
       - name: Notify if Update is Available
         if: steps.copier.outputs.check-update_update_available == 'true'
+        shell: bash
         env:
           APPRISE_URL: ${{ secrets.APPRISE_URL }}
         run: |

--- a/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-link_check.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-link_check.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
       - name: Check for Broken Links
+        shell: bash
         run: mise x -- lychee --no-progress -c .config/lychee.toml .
   workflow-keepalive:
     if: github.event_name == 'schedule'

--- a/template/{% if using_github %}.github{% endif %}/workflows/release-auto-prepare_release_pr.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/release-auto-prepare_release_pr.yml
@@ -18,11 +18,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: Configure Git
+        shell: bash
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email github-actions@github.com
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
       - name: Prepare Release PR
+        shell: bash
         run: mise x -- knope autoupdate-knope-pr --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/template/{% if using_github %}.github{% endif %}/workflows/release-auto-publish_release.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/release-auto-publish_release.yml
@@ -19,6 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
       - name: Publish Release
+        shell: bash
         run: mise x -- knope release-on-knope-pr-merge --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/template/{% if using_github %}.github{% endif %}/workflows/release-manual-create_prerelease.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/release-manual-create_prerelease.yml
@@ -12,6 +12,9 @@ on:
           - beta
           - rc
 
+env:
+  MISE_ENV: ci
+
 jobs:
   create-prerelease-via-knope:
     runs-on: ubuntu-latest
@@ -24,27 +27,27 @@ jobs:
         with:
           fetch-depth: 0
       - name: Block Duplicate Prerelease
-        shell: pwsh
+        shell: bash
         env:
           LABEL: ${{ inputs.label }}
         run: |
-          $tags = git tag --points-at HEAD
-          $duplicate = $tags | Where-Object { $_ -match "-$([regex]::Escape($env:LABEL))\.\d+$" }
-          if ($duplicate) {
-            Write-Host "::error::This commit is already tagged as $duplicate -- push a new commit before cutting another $($env:LABEL) prerelease."
+          duplicate=$(git tag --points-at HEAD | grep -E -- "-${LABEL}\.[0-9]+$" || true)
+          if [ -n "$duplicate" ]; then
+            echo "::error::This commit is already tagged as $duplicate -- push a new commit before cutting another $LABEL prerelease."
             exit 1
-          }
+          fi
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
       - name: Create Prerelease
+        shell: bash
         run: mise x -- knope create-prerelease-via-knope --prerelease-label ${{ inputs.label }} --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Capture Version
         id: version
-        shell: pwsh
+        shell: bash
         run: |
-          $version = (Get-Content .config/knope-current-version.json -Raw | ConvertFrom-Json).version
-          "version=$version" >> $env:GITHUB_OUTPUT
+          version=$(mise x -- jq -r '.version' .config/knope-current-version.json)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Emit Release Notice
-        shell: pwsh
+        shell: bash
         run: echo "::notice title=Prerelease Published::https://github.com/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.version }}"

--- a/template/{% if using_github %}.github{% endif %}/workflows/test-auto-pr_validation.yml.jinja
+++ b/template/{% if using_github %}.github{% endif %}/workflows/test-auto-pr_validation.yml.jinja
@@ -22,10 +22,12 @@ jobs:
           fetch-depth: 0
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
       - name: Check PR Title is a Conventional Commit
+        shell: bash
         env:
           PR_TITLE: {% raw %}${{ github.event.pull_request.title }}{% endraw %}
         run: echo "$PR_TITLE" | mise x -- committed --config .config/committed.toml --commit-file -
       - name: Run Prek Tests
+        shell: bash
         env:
           BASE_REF: {% raw %}${{ github.base_ref }}{% endraw %}
         run: |
@@ -40,6 +42,7 @@ jobs:
           fi
 {%- if is_template %}
       - name: Run Template Render Tests
+        shell: bash
         run: |-
           mise x -- pytest tests/
 {%- endif %}

--- a/template/{% if using_github %}.github{% endif %}/workflows/{% if is_template and integration_test_scheduled %}test-auto-integration_test.yml{% endif %}
+++ b/template/{% if using_github %}.github{% endif %}/workflows/{% if is_template and integration_test_scheduled %}test-auto-integration_test.yml{% endif %}
@@ -32,6 +32,7 @@ jobs:
         # creates under whichever account INTEGRATION_TEST_PAT authenticates as, not
         # necessarily this repo's own owner. GITHUB_REPOSITORY is always set by GitHub
         # regardless of trigger type, so this doesn't need to be templated.
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.INTEGRATION_TEST_PAT }}
         run: |
@@ -68,6 +69,7 @@ jobs:
           key: azure-devops-cli-ext-${{ runner.os }}
           path: ~/.azure/cliextensions
       - name: Install Azure DevOps CLI Extension
+        shell: bash
         run: |
           az extension list -o tsv --query "[?name=='azure-devops'].name" | grep -q azure-devops || \
             az extension add --name azure-devops --only-show-errors
@@ -78,6 +80,7 @@ jobs:
         # why it targets Azure DevOps regardless of this project's own
         # developer_platform. AZURE_DEVOPS_EXT_PAT is the exact env var name the
         # az CLI's azure-devops extension auto-detects for non-interactive auth.
+        shell: bash
         env:
           AZURE_DEVOPS_EXT_PAT: ${{ secrets.AZURE_DEVOPS_EXT_PAT }}
         run: |

--- a/template/{% if using_github %}.github{% endif %}/workflows/{% if zensical_ghpages %}docs-auto-zensical.yml{% endif %}
+++ b/template/{% if using_github %}.github{% endif %}/workflows/{% if zensical_ghpages %}docs-auto-zensical.yml{% endif %}
@@ -31,11 +31,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: Configure Git Credentials
+        shell: bash
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
-      - run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
+      - shell: bash
+        run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           key: zensical-${{ env.cache_id }}
@@ -47,17 +49,21 @@ jobs:
         # jiangxin/file-exists-action is unmaintained (GitHub flags it) -- this is
         # simple enough to inline. fetch-depth: 0 above fetches all branches, so
         # origin/gh-pages is resolvable locally without a separate checkout.
+        shell: bash
         run: |
           if git cat-file -e origin/gh-pages:index.html 2>/dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
-      - run: mike set-default --push --allow-undefined dev
+      - shell: bash
+        run: mike set-default --push --allow-undefined dev
         if: ${{ steps.index-check.outputs.exists == 'false' }}
-      - run: mike deploy --push --update-aliases dev
+      - shell: bash
+        run: mike deploy --push --update-aliases dev
         if: ${{ github.event_name == 'push' }}
-      - run: |
+      - shell: bash
+        run: |
           mike deploy --push --update-aliases ${{ github.event.release.tag_name }} latest
           mike set-default --push latest
         if: ${{ github.event_name == 'release' }}

--- a/template/{% if using_github %}.github{% endif %}/workflows/{% if zensical_repo %}docs-auto-mkdocs.yml{% endif %}
+++ b/template/{% if using_github %}.github{% endif %}/workflows/{% if zensical_repo %}docs-auto-mkdocs.yml{% endif %}
@@ -28,18 +28,21 @@ jobs:
           secrets: |
             REPO_MAINTENANCE_PAT=${{ secrets.REPO_MAINTENANCE_PAT }}
       - name: Configure Git Credentials
+        shell: bash
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
-      - run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
+      - shell: bash
+        run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           key: zensical-${{ env.cache_id }}
           path: ~/.cache
           restore-keys: |
             zensical-
-      - run: zensical build
+      - shell: bash
+        run: zensical build
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8


### PR DESCRIPTION
Converts the last 4 PowerShell steps to Bash (require-secrets, and Block Duplicate Prerelease/Capture Version/Emit Release Notice in release-manual-create_prerelease.yml) -- jq and grep -E replace ConvertFrom-Json and -match, both preinstalled on GitHub-hosted runners and standard on Unix self-hosted ones. Adds jq to mise.ci.toml so it's guaranteed even where it isn't preinstalled.

Also pins shell: bash explicitly on every other run: step across all GitHub workflows, not just the ones that changed. Those were bash only by accident of every job here running on ubuntu-latest -- unpinned, they'd silently default to pwsh (and fail on their bash syntax) the moment any job's runner ever became a Windows one, hosted or self-hosted.