### PR TITLE
fix: remove now-obsolete _old_tag_overrides from answer_matrix.py

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,13 @@
   under 72 characters). A short body paragraph explaining non-obvious
   rationale is fine when it adds real context; don't pad a trivial change with
   one just to have one.
+- Never push a git tag to this repo without explicit user approval for that
+  specific tag, and never push one shaped like a version number (e.g.
+  `v99.0.0`) even as a throwaway testing workaround -- this repo's tags are
+  visible to any downstream project that copies from it, and a real one could
+  resolve against a stray tag. A non-version-shaped tag for local testing is
+  fine to create without asking, but delete it immediately once the test that
+  needed it is done.
 
 ## Render-validation test suite
 

--- a/template/{% if agent_instructions %}AGENTS.md{% endif %}.jinja
+++ b/template/{% if agent_instructions %}AGENTS.md{% endif %}.jinja
@@ -8,6 +8,13 @@
   rationale is fine when it adds real context; don't pad a trivial change with
   one just to have one.
 {%- if is_template %}
+- Never push a git tag to this repo without explicit user approval for that
+  specific tag, and never push one shaped like a version number (e.g.
+  `v99.0.0`) even as a throwaway testing workaround -- this repo's tags are
+  visible to any downstream project that copies from it, and a real one could
+  resolve against a stray tag. A non-version-shaped tag for local testing is
+  fine to create without asking, but delete it immediately once the test that
+  needed it is done.
 
 ## Render-validation test suite
 

--- a/template/{% if is_template %}scripts{% endif %}/integration_test_azdo.py
+++ b/template/{% if is_template %}scripts{% endif %}/integration_test_azdo.py
@@ -893,6 +893,17 @@ def open_pr_wait_and_merge(
         "completed",
         "--squash",
         "true",
+        # Without this, Azure DevOps writes a generic "Merge pull request N from
+        # <branch> into main" squash commit message instead of the PR title -- unlike
+        # GitHub, which defaults a squash merge's commit message to the PR title.
+        # knope's PrepareRelease step parses Conventional Commits from real git commit
+        # messages, so a squashed test commit that loses its "fix:"/"feat:" prefix this
+        # way silently stops counting as a qualifying commit once a tag already exists
+        # (confirmed live: after the first release, this caused knope's own
+        # create-prerelease-via-knope workflow to fail with "No packages are ready to
+        # release" even though a real fix commit had just been merged).
+        "--merge-commit-message",
+        commit_message,
         "--delete-source-branch",
         "true",
         "--org",

--- a/template/{% if is_template %}tests{% endif %}/answer_matrix.py
+++ b/template/{% if is_template %}tests{% endif %}/answer_matrix.py
@@ -39,11 +39,6 @@ ANSWER_MATRIX = [
         "project_visibility": "Private",
         "license": "None",
         "zensical_target": "docs-site Directory in Repo",
-        # "docs-site Directory in Repo" was "docs_site Directory in Repo" before this
-        # repo's own hyphenation rename -- the last tag predates that, so
-        # test_update_from_last_tag's initial copy-at-old-tag needs the old value.
-        # Remove once the last tag postdates the rename.
-        "_old_tag_overrides": {"zensical_target": "docs_site Directory in Repo"},
         "lifecycle": "Stable",
     },
     {
@@ -68,7 +63,6 @@ ANSWER_MATRIX = [
         "project_visibility": "Private",
         "license": "None",
         "zensical_target": "docs-site Directory in Repo",
-        "_old_tag_overrides": {"zensical_target": "docs_site Directory in Repo"},
         "lifecycle": "Beta",
         "code_coverage": True,
     },
@@ -82,7 +76,6 @@ ANSWER_MATRIX = [
         "project_visibility": "Private",
         "license": "None",
         "zensical_target": "docs-site Directory in Repo",
-        "_old_tag_overrides": {"zensical_target": "docs_site Directory in Repo"},
         "lifecycle": "Alpha",
     },
 ]

--- a/tests/answer_matrix.py
+++ b/tests/answer_matrix.py
@@ -39,11 +39,6 @@ ANSWER_MATRIX = [
         "project_visibility": "Private",
         "license": "None",
         "zensical_target": "docs-site Directory in Repo",
-        # "docs-site Directory in Repo" was "docs_site Directory in Repo" before this
-        # repo's own hyphenation rename -- the last tag predates that, so
-        # test_update_from_last_tag's initial copy-at-old-tag needs the old value.
-        # Remove once the last tag postdates the rename.
-        "_old_tag_overrides": {"zensical_target": "docs_site Directory in Repo"},
         "lifecycle": "Stable",
     },
     {
@@ -68,7 +63,6 @@ ANSWER_MATRIX = [
         "project_visibility": "Private",
         "license": "None",
         "zensical_target": "docs-site Directory in Repo",
-        "_old_tag_overrides": {"zensical_target": "docs_site Directory in Repo"},
         "lifecycle": "Beta",
         "code_coverage": True,
     },
@@ -82,7 +76,6 @@ ANSWER_MATRIX = [
         "project_visibility": "Private",
         "license": "None",
         "zensical_target": "docs-site Directory in Repo",
-        "_old_tag_overrides": {"zensical_target": "docs_site Directory in Repo"},
         "lifecycle": "Alpha",
     },
 ]


### PR DESCRIPTION
v0.8.0's tag postdates the underscore-to-hyphen rename these existed for, so test_update_from_last_tag no longer needs to fake the old zensical_target value when copying at the last tag.