### PR TITLE
feat: generate changesets from upstream template updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,13 @@ Two exceptions:
   staleness causes an active problem right now (not just "missing a new
   feature until the next update") -- e.g. `renovate.json`, which Renovate
   reads directly on its own schedule regardless of `copier update`. Treat
-  syncing those as a deliberate, flagged exception, not the default.
+  syncing those as a deliberate, flagged exception, not the default. Root
+  `knope.toml` joins this list specifically for any workflow that
+  `copier.yml`'s `_migrations` scripts invoke by cloning this repo (e.g.
+  `compute-upstream-bump`) -- that clone gets whatever's actually committed to
+  root `knope.toml`, not `template/knope.toml.jinja`, so a workflow that only
+  exists in the template source silently fails with "unrecognized subcommand"
+  in every child's migration until root catches up.
 
 When validating template changes (e.g. testing uncommitted edits), don't copy
 this repo's root as a Copier source -- either render fresh from `template/` or

--- a/copier.yml
+++ b/copier.yml
@@ -57,6 +57,118 @@ _migrations:
                 print(f"Reformatted {count} changelog heading(s) for Knope.")
     version: v0.8.1
     when: "{{ _stage == 'after' }}"
+
+  # No `version:` -- this runs on every update, not just once, so upstream changes
+  # actually show up in this project's own changelog instead of vanishing into an
+  # opaque "chore: apply parent template" commit. Computes the real bump/changelog
+  # content by running Knope's own compute-upstream-bump workflow for real (not
+  # --dry-run) inside a throwaway clone of the template, with every tag but this
+  # project's old template version hidden so Knope's own "most recent tag" baseline
+  # lands on the actual delta -- see that workflow's comment in knope.toml for why.
+  # Silently does nothing if there's no qualifying commit to bump (e.g. an
+  # internal-only template change) or if the old version isn't a real tag in the
+  # template's history.
+  - command:
+      - mise
+      - x
+      - --
+      - python
+      - -c
+      - |
+        import json
+        import re
+        import shutil
+        import subprocess
+        import sys
+        import tempfile
+        from pathlib import Path
+
+        version_from, version_to, src_path, answers_file = (
+            sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4],
+        )
+        if version_from == version_to:
+            sys.exit(0)
+
+        # The recorded source, not a hardcoded repo name -- a grandchild updating
+        # from a child template that itself descends from this one has its own
+        # upstream, not this repo.
+        upstream = src_path
+        answers_path = Path(answers_file)
+        if answers_path.is_file():
+            match = re.search(
+                r"^_src_path:\s*(\S+)", answers_path.read_text(encoding="utf-8"),
+                re.MULTILINE,
+            )
+            if match:
+                upstream = match.group(1)
+
+        def run(*args, cwd=None, check=True):
+            return subprocess.run(
+                args, cwd=cwd, check=check, capture_output=True, text=True
+            )
+
+        scratch = Path(tempfile.mkdtemp())
+        try:
+            run("git", "clone", "--quiet", src_path, str(scratch))
+            tags = run("git", "tag", cwd=scratch).stdout.split()
+            if version_from not in tags:
+                sys.exit(0)
+            run("git", "checkout", "--quiet", version_to, cwd=scratch)
+            for tag in tags:
+                if tag != version_from:
+                    run("git", "tag", "-d", tag, cwd=scratch, check=False)
+
+            result = run(
+                "mise", "x", "--", "knope", "compute-upstream-bump",
+                cwd=scratch, check=False,
+            )
+            if result.returncode != 0:
+                sys.exit(0)
+
+            new_version = json.loads(
+                (scratch / ".config" / "knope-current-version.json").read_text(
+                    encoding="utf-8"
+                )
+            )["version"]
+            changelog = (scratch / "CHANGELOG.md").read_text(
+                encoding="utf-8", newline=""
+            )
+            headings = [
+                m.start() for m in re.finditer(r"^## ", changelog, re.MULTILINE)
+            ]
+            end = headings[1] if len(headings) > 1 else len(changelog)
+            entry = changelog[headings[0]:end].strip()
+            body = entry.split("\n", 1)[1].strip() if "\n" in entry else ""
+
+            def parts(v):
+                return tuple(int(x) for x in v.lstrip("v").split("."))
+
+            old_parts, new_parts = parts(version_from), parts(new_version)
+            if new_parts[0] != old_parts[0]:
+                bump = "major"
+            elif new_parts[1] != old_parts[1]:
+                bump = "minor"
+            else:
+                bump = "patch"
+
+            changeset_dir = Path(".changeset")
+            changeset_dir.mkdir(exist_ok=True)
+            filename = f"template-update-{version_to.lstrip('v')}.md"
+            (changeset_dir / filename).write_text(
+                f"---\ndefault: {bump}\n---\n\n"
+                f"# Update from {upstream} {version_to}\n\n"
+                f"{body}\n",
+                encoding="utf-8",
+                newline="",
+            )
+            print(f"Added changeset .changeset/{filename} ({bump}).")
+        finally:
+            shutil.rmtree(scratch, ignore_errors=True)
+      - "{{ _version_from }}"
+      - "{{ _version_to }}"
+      - "{{ _copier_conf.src_path }}"
+      - "{{ _copier_conf.answers_file }}"
+    when: "{{ _stage == 'after' }}"
 ## End Migrations
 
 ## Start Pre-Question Computed Values
@@ -828,5 +940,14 @@ _message_after_update: |-
 
   knope autoupdate-knope-pr --override-version 1.0.0
   {%- endif %}
+  {%- endif %}
+  {%- set changesets = ('python -c "import glob; print(chr(10).join(glob.glob(\'.changeset/*.md\')))"' | shell()) -%}
+  {%- if changesets.strip() %}
+
+  This project has pending changeset(s) describing upstream template updates:
+  {{ changesets }}
+  Some of what changed upstream (platform-specific fixes, template-internal
+  tooling, etc.) may not be relevant here -- review and trim them before your
+  next release.
   {%- endif %}
 ## End Messages

--- a/knope.toml
+++ b/knope.toml
@@ -33,16 +33,23 @@ template = "chore: prepare release $version"
 template = "This PR was created by Knope. Merging it will create a new release (v$version).\n\n$changelog\n\n- [ ] Integration tests have been run and passed (or N/A)"
 
 [[workflows]]
-name = "prepare-release-only"
-
-[[workflows.steps]]
-type = "PrepareRelease"
-
-[[workflows]]
 name = "release-on-knope-pr-merge"
 
 [[workflows.steps]]
 type = "Release"
+
+[[workflows]]
+# Used only by copier.yml's _migrations, inside a scratch clone of the template repo
+# with every tag but the project's old template version hidden -- PrepareRelease
+# always bumps from "the most recent reachable tag", so hiding the rest is what makes
+# it compute the real delta across a multi-version jump instead of just the last hop.
+# Run for real (not --dry-run): the scratch clone is thrown away either way, and
+# reading the version file and CHANGELOG.md it actually writes is far more robust than
+# scraping human-readable dry-run log output.
+name = "compute-upstream-bump"
+
+[[workflows.steps]]
+type = "PrepareRelease"
 
 [[workflows]]
 name = "create-prerelease-via-knope"

--- a/template/knope.toml.jinja
+++ b/template/knope.toml.jinja
@@ -54,6 +54,19 @@ command = "git push --tags"
 {%- endif %}
 
 [[workflows]]
+# Used only by copier.yml's _migrations, inside a scratch clone of the template repo
+# with every tag but the project's old template version hidden -- PrepareRelease
+# always bumps from "the most recent reachable tag", so hiding the rest is what makes
+# it compute the real delta across a multi-version jump instead of just the last hop.
+# Run for real (not --dry-run): the scratch clone is thrown away either way, and
+# reading the version file and CHANGELOG.md it actually writes is far more robust than
+# scraping human-readable dry-run log output.
+name = "compute-upstream-bump"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+
+[[workflows]]
 name = "create-prerelease-via-knope"
 
 [[workflows.steps]]

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -70,6 +70,118 @@ _migrations:
                 print(f"Reformatted {count} changelog heading(s) for Knope.")
     version: v0.8.1
     when: "{{ _stage == 'after' }}"
+
+  # No `version:` -- this runs on every update, not just once, so upstream changes
+  # actually show up in this project's own changelog instead of vanishing into an
+  # opaque "chore: apply parent template" commit. Computes the real bump/changelog
+  # content by running Knope's own compute-upstream-bump workflow for real (not
+  # --dry-run) inside a throwaway clone of the template, with every tag but this
+  # project's old template version hidden so Knope's own "most recent tag" baseline
+  # lands on the actual delta -- see that workflow's comment in knope.toml for why.
+  # Silently does nothing if there's no qualifying commit to bump (e.g. an
+  # internal-only template change) or if the old version isn't a real tag in the
+  # template's history.
+  - command:
+      - mise
+      - x
+      - --
+      - python
+      - -c
+      - |
+        import json
+        import re
+        import shutil
+        import subprocess
+        import sys
+        import tempfile
+        from pathlib import Path
+
+        version_from, version_to, src_path, answers_file = (
+            sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4],
+        )
+        if version_from == version_to:
+            sys.exit(0)
+
+        # The recorded source, not a hardcoded repo name -- a grandchild updating
+        # from a child template that itself descends from this one has its own
+        # upstream, not this repo.
+        upstream = src_path
+        answers_path = Path(answers_file)
+        if answers_path.is_file():
+            match = re.search(
+                r"^_src_path:\s*(\S+)", answers_path.read_text(encoding="utf-8"),
+                re.MULTILINE,
+            )
+            if match:
+                upstream = match.group(1)
+
+        def run(*args, cwd=None, check=True):
+            return subprocess.run(
+                args, cwd=cwd, check=check, capture_output=True, text=True
+            )
+
+        scratch = Path(tempfile.mkdtemp())
+        try:
+            run("git", "clone", "--quiet", src_path, str(scratch))
+            tags = run("git", "tag", cwd=scratch).stdout.split()
+            if version_from not in tags:
+                sys.exit(0)
+            run("git", "checkout", "--quiet", version_to, cwd=scratch)
+            for tag in tags:
+                if tag != version_from:
+                    run("git", "tag", "-d", tag, cwd=scratch, check=False)
+
+            result = run(
+                "mise", "x", "--", "knope", "compute-upstream-bump",
+                cwd=scratch, check=False,
+            )
+            if result.returncode != 0:
+                sys.exit(0)
+
+            new_version = json.loads(
+                (scratch / ".config" / "knope-current-version.json").read_text(
+                    encoding="utf-8"
+                )
+            )["version"]
+            changelog = (scratch / "CHANGELOG.md").read_text(
+                encoding="utf-8", newline=""
+            )
+            headings = [
+                m.start() for m in re.finditer(r"^## ", changelog, re.MULTILINE)
+            ]
+            end = headings[1] if len(headings) > 1 else len(changelog)
+            entry = changelog[headings[0]:end].strip()
+            body = entry.split("\n", 1)[1].strip() if "\n" in entry else ""
+
+            def parts(v):
+                return tuple(int(x) for x in v.lstrip("v").split("."))
+
+            old_parts, new_parts = parts(version_from), parts(new_version)
+            if new_parts[0] != old_parts[0]:
+                bump = "major"
+            elif new_parts[1] != old_parts[1]:
+                bump = "minor"
+            else:
+                bump = "patch"
+
+            changeset_dir = Path(".changeset")
+            changeset_dir.mkdir(exist_ok=True)
+            filename = f"template-update-{version_to.lstrip('v')}.md"
+            (changeset_dir / filename).write_text(
+                f"---\ndefault: {bump}\n---\n\n"
+                f"# Update from {upstream} {version_to}\n\n"
+                f"{body}\n",
+                encoding="utf-8",
+                newline="",
+            )
+            print(f"Added changeset .changeset/{filename} ({bump}).")
+        finally:
+            shutil.rmtree(scratch, ignore_errors=True)
+      - "{{ _version_from }}"
+      - "{{ _version_to }}"
+      - "{{ _copier_conf.src_path }}"
+      - "{{ _copier_conf.answers_file }}"
+    when: "{{ _stage == 'after' }}"
 ## End Migrations
 
 ## Start Pre-Question Computed Values
@@ -841,6 +953,15 @@ _message_after_update: |-
 
   knope autoupdate-knope-pr --override-version 1.0.0
   {%- endif %}
+  {%- endif %}
+  {%- set changesets = ('python -c "import glob; print(chr(10).join(glob.glob(\'.changeset/*.md\')))"' | shell()) -%}
+  {%- if changesets.strip() %}
+
+  This project has pending changeset(s) describing upstream template updates:
+  {{ changesets }}
+  Some of what changed upstream (platform-specific fixes, template-internal
+  tooling, etc.) may not be relevant here -- review and trim them before your
+  next release.
   {%- endif %}
 ## End Messages
 {%- endraw %}


### PR DESCRIPTION
Copier updates from this template previously landed in child projects as a single non-releasing "chore: apply parent template" commit -- upstream fixes/features never surfaced in the child's own changelog or version. Add a copier _migrations entry (runs on every update, not just once) that runs Knope's own commit classification for real against a throwaway clone of the template, then writes a changeset describing what actually changed.

Reuses Knope's new compute-upstream-bump workflow rather than reimplementing Conventional Commits parsing: run for real (not --dry-run) so the bump level and changelog content come from files it actually writes, not scraped log text. Every tag but the child's old template version is hidden first, since PrepareRelease always bumps from "the most recent reachable tag" with no way to override the baseline -- without that, a multi-version jump would only see the last hop's commits. The changeset's title reads the recorded _src_path rather than naming this repo, so a grandchild updating from a child template correctly credits its own upstream. A reminder that some of what changed upstream may not be relevant to this project prints via _message_after_update, guaranteed visible at the end of the run rather than buried in migration output.

Verified live end-to-end: a multi-version jump correctly detects a MINOR bump, the review reminder renders correctly, and the child's own next release picks the changeset up exactly as Knope's docs describe.

Also syncs root knope.toml, which the migration's scratch clone reads directly -- see the new AGENTS.md note on why this file joins copier.yml/renovate.json as a load-bearing root exception.