### PR TITLE
fix: rename Link Check to Repo Health Check in AzDO pipeline check

### DIFF
--- a/template/{% if is_template %}scripts{% endif %}/integration_test_azdo.py
+++ b/template/{% if is_template %}scripts{% endif %}/integration_test_azdo.py
@@ -48,7 +48,7 @@ PROJECT_DESCRIPTION = "Integration Test - NOT FOR PUBLIC USE, safe to delete"
 # `az pipelines create --name "[<repo_name>] <name>"` _tasks entries.
 PIPELINE_DISPLAY_NAMES = (
     "Maint (Auto) - Copier Update Check",
-    "Maint (Auto) - Link Check",
+    "Maint (Auto) - Repo Health Check",
     "Maint (Auto) - Renovate",
     "Docs (Auto) - Zensical Build & Publish",
     "Test (Auto) - PR Validation",


### PR DESCRIPTION
PIPELINE_DISPLAY_NAMES still said "Maint (Auto) - Link Check" after that pipeline's rename to "Maint (Auto) - Repo Health Check" -- a gap between two PRs that merged close together, each touching a different part of this same list.