### PR TITLE
chore: prepare release 0.8.1

### DIFF
--- a/.config/knope-current-version.json
+++ b/.config/knope-current-version.json
@@ -1,4 +1,4 @@
 {
   "_comment": "Managed by Knope -- do not edit manually.",
-  "version": "0.8.0"
+  "version": "0.8.1"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.8.1 (2026-08-30)
+
+### Features
+
+- generate changesets from upstream template updates (#1099)
+- fold REPO_MAINTENANCE_PAT expiration check into a repo health check (#1100)
+- add extending-the-template guide and a docs preview tool (#1106)
+
+### Fixes
+
+- remove now-obsolete _old_tag_overrides from answer_matrix.py (#1094)
+- fix knope current version (#1096)
+- reformat CHANGELOG.md headings for Knope compatibility (#1097)
+- cover Release (Manual) - Create Prerelease in AzDO pipeline check (#1101)
+- rename Link Check to Repo Health Check in AzDO pipeline check (#1102)
+- sync root workflow/copier.yml with the knope-native PR revert (#1103)
+- close two Renovate coverage gaps and document a third (#1105)
+
 ## 0.8.0 (2026-08-28)
 
 


### PR DESCRIPTION
This PR was created by Knope. Merging it will create a new release (v0.8.1).

## Features

- generate changesets from upstream template updates (#1099)
- fold REPO_MAINTENANCE_PAT expiration check into a repo health check (#1100)
- add extending-the-template guide and a docs preview tool (#1106)

## Fixes

- remove now-obsolete _old_tag_overrides from answer_matrix.py (#1094)
- fix knope current version (#1096)
- reformat CHANGELOG.md headings for Knope compatibility (#1097)
- cover Release (Manual) - Create Prerelease in AzDO pipeline check (#1101)
- rename Link Check to Repo Health Check in AzDO pipeline check (#1102)
- sync root workflow/copier.yml with the knope-native PR revert (#1103)
- close two Renovate coverage gaps and document a third (#1105)

- [ ] Integration tests have been run and passed (or N/A)