### PR TITLE
fix: close two Renovate coverage gaps and document a third

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -262,9 +262,21 @@
         "/mise\\..*toml(?:\\.jinja)?/"
       ],
       "matchStrings": [
-        ".*?(--with\\s(?<depName>.+?)(\\[\\S+])*==(?<currentValue>[^\"\\s]*))"
+        ".*?(--with\\s(?<depName>.+?)(\\[\\S+])*==(?<currentValue>[^\"\\s{]*))"
       ],
       "versioningTemplate": "pep440"
+    },
+    {
+      "description": "Manager for npm-backed mise tools with options -- mirrors \"Manager for pipx tools with options\" above, but for the npm: backend prefix (datasource npm instead of pypi). A separate manager because that one's datasource is hardcoded to pypi.",
+      "customType": "regex",
+      "datasourceTemplate": "npm",
+      "managerFilePatterns": [
+        "/mise\\..*toml(?:\\.jinja)?/"
+      ],
+      "matchStrings": [
+        "\\[tools\\.\"?npm:(?<depName>[A-Za-z0-9_.-]+)\"?\\]\\sversion = \"(?<currentValue>[^\\s]*)\""
+      ],
+      "versioningTemplate": "npm"
     }
   ]
 }

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -299,9 +299,22 @@
         {%- endif %}
       ],
       "matchStrings": [
-        ".*?(--with\\s(?<depName>.+?)(\\[\\S+])*==(?<currentValue>[^\"\\s]*))"
+        ".*?(--with\\s(?<depName>.+?)(\\[\\S+])*==(?<currentValue>[^\"\\s{]*))"
       ],
       "versioningTemplate": "pep440"
+    }{% if is_template %},
+    {
+      "description": "Manager for npm-backed mise tools with options -- mirrors \"Manager for pipx tools with options\" above, but for the npm: backend prefix (datasource npm instead of pypi). A separate manager because that one's datasource is hardcoded to pypi.",
+      "customType": "regex",
+      "datasourceTemplate": "npm",
+      "managerFilePatterns": [
+        "/mise\\..*toml(?:\\.jinja)?/"
+      ],
+      "matchStrings": [
+        "\\[tools\\.\"?npm:(?<depName>[A-Za-z0-9_.-]+)\"?\\]\\sversion = \"(?<currentValue>[^\\s]*)\""
+      ],
+      "versioningTemplate": "npm"
     }
+    {%- endif %}
   ]
 }

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/release-auto-release.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/release-auto-release.yml
@@ -43,6 +43,12 @@ stages:
           - bash: mise install
             displayName: Run 'mise install'
           - bash: az extension add --name azure-devops
+            # Deliberately unpinned as of 2026-08 -- no Renovate-trackable version
+            # source could be found. Its GitHub releases are date-tagged (don't match
+            # the real version number), and the matching-named PyPI package is an
+            # unrelated SDK. The real version list lives in Azure/azure-cli-extensions'
+            # src/index.json, which would need a custom JSONata datasource to track;
+            # revisit if Renovate gains native support for Azure CLI extensions.
             displayName: Install azure-devops CLI Extension
           - bash: az devops configure --defaults organization=$(System.CollectionUri) project="$(System.TeamProject)"
             displayName: Configure az CLI Defaults


### PR DESCRIPTION
Confirmed via a Node.js test against the real regexes (Renovate uses JS RegExp semantics), not guesswork:

1. mise.toml.jinja's pytest uvx_args line has 6 `--with X==Y` pins on one line; 3 were invisible on the Dependency Dashboard. Root cause: currentValue's character class didn't stop at `{`, so wherever a version number is immediately followed by Jinja syntax with no space (`3.8.0{% if ... %}`), it captured a corrupted value like `3.8.0{%` that Renovate silently can't parse -- not a matching failure, all 6 occurrences do match. Excluding `{` from the character class fixes all 6.

2. The npm:renovate tool pin (mise.ci.toml.jinja, AzDO's self-hosted Renovate version) was tracked by zero managers -- it has a `# renovate:` comment, but that manager only spans inline `key = "value"` pairs, and this entry needs the table form (it also sets trust_policy_excludes). The existing pipx-tools-with-options manager is hardcoded to the pipx: prefix and pypi datasource, so a new sibling manager was added for npm:-prefixed table-form tools.

3. The unpinned `az extension add --name azure-devops` install has no datasource Renovate can reliably track (GitHub release tags are date-stamped, not the real version; the matching-named PyPI package is an unrelated SDK) -- left unpinned per explicit direction, with a comment explaining why rather than a silent gap.

Also syncs root renovate.json, which Renovate reads directly on its own schedule per AGENTS.md's existing load-bearing-root-file note.