### PR TITLE
feat: add extending-the-template guide and a docs preview tool

### DIFF
--- a/template/mise.toml.jinja
+++ b/template/mise.toml.jinja
@@ -63,6 +63,15 @@ run = "python .azurepipelines/migrate_pipeline_names.py"
 [tasks.test]
 run = "pytest tests/"
 
+[tasks.template-docs-server]
+# Previews template/'s docs through a real zensical render, under every
+# ANSWER_MATRIX entry (deduped): there's no single answer set that renders the
+# whole docs/ tree correctly, since conditional content and conditional file paths
+# both depend on it. See the script's own docstring for the full reasoning.
+# Run via `uv run`, not plain `python`; its PEP 723 header pulls in rich,
+# tomlkit, and watchdog, none of which are otherwise a project dependency.
+run = "uv run scripts/template_docs_server.py"
+
 [tasks.integration-test-gh]
 # Creates two real throwaway repos from this template and runs every automated check
 # it can against Repo A, always at HEAD -- this exists to verify a release candidate

--- a/template/zensical.toml.jinja
+++ b/template/zensical.toml.jinja
@@ -25,6 +25,7 @@ nav = [
     "platform-notes/index.md",
     "platform-notes/azure-devops.md"
   ] },
+  { "Extending This Template" = "extending-the-template.md" },
   { "Components" = [
     "components/template-engine.md"
   ] }

--- a/template/{% if is_template %}docs{% endif %}/extending-the-template.md
+++ b/template/{% if is_template %}docs{% endif %}/extending-the-template.md
@@ -1,0 +1,110 @@
+# Extending This Template
+
+This template is deliberately universal: it provides the settings, CI/CD, release automation, and repo hygiene that apply to *any* Git-tracked project, regardless of what's actually in it. It's meant to be a common ancestor: a Python library template, a PowerShell module template, a Terraform-config template, and others all start from a `copier copy` of this one (with `project_type: Template`, which gives you your own copy of `template/` to build on) and then add whatever's specific to their own domain.
+
+That inheritance is the whole point, but it also means the discipline that keeps *this* template correct has to travel with you. Every mechanism this template relies on (the render tests, Renovate coverage, dual-platform CI, the migration story for existing downstream projects) is generic. None of it is specific to what this template happens to contain today. This page walks through applying that same discipline to whatever *you* add, starting with the one decision that shapes everything else.
+
+## Start here: will other templates build on yours?
+
+Resolve this before anything else: it decides how much of the rest of this page even applies to you.
+
+=== "Leaf template (most common)"
+
+    Your template produces finished projects and nothing ever copies *from* it again: it's the end of the chain. This is the lower-maintenance path, and the right default unless you specifically know otherwise:
+
+    - Drop the `project_type` axis from your own `copier.yml` (or hardcode it to whatever your one output shape is): there's no `Template` branch to carry if nothing downstream of you will ever itself be a template.
+    - Skip the `template/`-subtree-gated-by-`is_template` convention entirely. You have exactly one branch, not two.
+    - None of the obligations below about *your own* extensibility apply: you're not handing anyone else a template to extend.
+
+=== "Extensible template"
+
+    Your template can itself be copied with `project_type: Template` to become the parent of a further template, exactly the relationship this repo has to yours. That inheritance keeps costing you maintenance for as long as the template exists:
+
+    - Keep `project_type` (or your own equivalent axis) so children can choose `Template` vs `Standard`.
+    - Carry your own `template/` subtree convention forward, gated the same way this one is.
+    - You inherit the obligation this page is discharging right now: a "what touches what" guide of your own, for whoever extends *you* next. Adapt this page rather than starting from a blank one: most of it (dependency pinning, Renovate coverage, the CI checklist, the testing layers) is generic to *any* Copier template, not specific to this one.
+
+!!! tip "When leaf is the right call"
+    An internal, single-company template usually doesn't need the extensible path: there's no third party waiting to fork it, and carrying the `Template`/`Standard` branch (the extra axis, the extra conditionals, the extra questions to explain, the extra answer combinations the render-validation suite has to exercise) is dead weight your maintainers pay for indefinitely with no one ever spending it. Choose extensible because you *know* another template will sit on top of yours, not because it seems more flexible to leave the door open.
+
+## The mental model
+
+Everything in this template varies along a small number of axes, and every question, file, and check either applies to all combinations or is explicitly gated to the ones it belongs to:
+
+- **`developer_platform`** (`GitHub` / `Azure DevOps`): most capabilities exist in parallel on both platforms, a GitHub Actions workflow has an Azure Pipelines counterpart, a GitHub secret has an Azure Pipeline variable, and so on. `using_github`/`using_azdo` gate the difference.
+- **`project_type`** (`Template` / `Standard`): `is_template` gates everything that only makes sense for a project that is itself a Copier template (the `template/` subtree, integration test scripts, this very page). `is_standard` is its complement. Whether *your* template keeps this axis at all is the fork you just resolved above.
+- Whatever new axis *you* introduce. A Python library template might add a `package_manager` question (`uv` / `poetry`); a Terraform template might add one for `terraform` / `opentofu`. Each answer (and, more importantly, each *combination* of answers) is something the render-validation suite has to actually exercise (see [Testing what you add](#testing-what-you-add)).
+
+Adding a new axis is a real decision, not a casual one: it multiplies the combinations everything else needs to keep working for. Prefer extending an existing axis's *options* over introducing a wholly new axis when the two are conceptually close.
+
+## Workflow: extending the template
+
+Once you know which fork you're on, everything else is the same kind of work repeated for whatever you're adding. Work through whichever checklist below matches what you're touching: most changes only need one, and a bigger change (a new tool that also needs a secret and a CI check) just means working through more than one in sequence.
+
+### Adding a new versioned dependency or tool
+
+This is the exercise that prompted this page; see [Token Permissions](token-permissions.md) and this template's own `renovate.json` for the concrete patterns referenced below.
+
+1. **Pin it.** A floating tag, `latest`, or an unversioned install script is a reproducibility gap. If you genuinely can't find a trackable version source for something (rare, but it happens), document *why* in a comment next to the install step rather than leaving a silent gap.
+2. **Wire it into `mise.toml`/`mise.ci.toml`** (or your own analog) with an exact version, not a range.
+3. **Make sure Renovate can actually see it.** Check `renovate.json`'s existing `customManagers` for a manager that already covers the shape of what you're adding (a `# renovate: datasource=... depName=...` comment above an inline `key = "value"` pin covers most simple cases). If nothing fits, you'll likely need a new custom regex manager.
+4. **Group related packages** if the same underlying dependency shows up under more than one name across ecosystems (e.g. a tool that's both a mise tool `depName` and a GitHub Action `depName`): a `packageRules` entry with a shared `groupName` keeps Renovate from opening two PRs for the same bump.
+
+!!! warning "Verify it, don't assume it"
+    A regex manager that looks right can still fail silently: a captured version string that includes trailing garbage (a Jinja tag with no space before it, a stray quote) won't error, it'll just get quietly dropped by Renovate during its own parsing. The reliable way to check: after `git push`, open the repo's **Dependency Dashboard** issue (Renovate creates one automatically) and confirm your dependency actually appears under **Detected Dependencies**, with the version you expect, not garbled, not missing. If you want to check a specific regex's matching behavior before pushing at all, test it directly against the real file content with a same-language regex engine (Renovate itself uses JS `RegExp` semantics) rather than reasoning about it by eye.
+
+### Adding a new Copier question
+
+1. Add the question to `copier.yml`, with a `when:`/`validator:` if it's conditional or constrained.
+2. Add real, reachable combinations to `answer_matrix.py`'s `ANSWER_MATRIX`; if you added a `validator:`, also add a combination it's supposed to reject to `INVALID_ANSWER_MATRIX`. `test_answer_matrix_coverage.py` audits `answer_matrix.py` itself against the real question set, so a forgotten entry won't pass silently.
+3. Decide whether the question needs representation in **every** existing answer combination, or just some; make sure `ANSWER_MATRIX`'s existing entries reflect that (a new axis usually means revisiting entries that predate it).
+4. If it changes what a fresh `copier copy` sets up, consider whether `_message_after_copy` needs a line about it, and whether `docs/` (particularly a template-questions-style reference) needs updating.
+
+### Adding a new CI workflow or pipeline
+
+1. Build **both** platform variants together, not one now and the other "later": a platform gap tends to stay a gap. Match the established naming convention (`Category (Auto/Manual): Name` on GitHub, `Category (Auto/Manual) - Name` on Azure DevOps).
+2. On Azure DevOps, pipelines are live registered objects, not just files; wire the new one into the `_tasks` `az pipelines create` bootstrap so a fresh `copier copy` registers it.
+3. Add a check for it to the integration test scripts (a `check_X()` function, plus the pipeline's display name in whatever coverage list `integration_test_azdo.py` maintains) so a real run actually exercises it, not just a local render.
+4. Add whatever can't be automated to the manual verification checklists (`docs/manual-verification-github.md` / `-azdo.md`): anything that depends on an external system's own behavior (a real notification landing, a third-party bot responding) belongs there, not in the automated scripts.
+5. If it needs a secret, work through the next checklist too.
+6. Any new SHA-pinned action, `az pipelines create`d task version, or embedded tool version this workflow introduces goes through the dependency checklist above too.
+
+### Adding a new secret or credential
+
+1. Document what it's for and what scope/permissions it needs in `docs/token-permissions.md`.
+2. Add it to the `provision-secrets` task (masked-prompt entry via `gh secret set` / `az pipelines variable create`) so setup stays a single guided step.
+3. Validate its presence in every consuming workflow/pipeline (the `require-secrets`-composite-action pattern on GitHub; an equivalent guard step on Azure DevOps) so a missing secret fails with a clear message instead of a confusing downstream error.
+4. Add it to `_message_after_copy`'s setup checklist.
+5. Consider whether it can expire, and if so, whether an expiration check belongs somewhere: this template's own `REPO_MAINTENANCE_PAT` check (folded into the monthly repo health check) is a working example of that pattern: authenticate as the credential itself, read whatever the platform's API reports about its expiration, and notify ahead of time rather than letting it fail silently later.
+
+### Renaming or removing something
+
+The tricky part isn't the rename itself: it's everyone who already copied the *old* name. A plain file rename or removal doesn't need anything special: Copier's own diff-based `update` already deletes what's gone and adds what's new in the current template, the same way it applies any other change.
+
+1. Update every place that referenced the old name: integration test scripts, manual verification checklists, any coverage list that enumerates things by name (these are exactly the kind of cross-reference that's easy to miss: this template's own `PIPELINE_DISPLAY_NAMES` list has had real, found-after-the-fact gaps from renames that touched every *other* reference but that one).
+2. If the value itself needs transforming (not just diffed away and re-added), a `_migrations` entry is the place for that: reformatting existing content in a file so a downstream tool can parse it, or converting old data into a new shape. Give it no `version:` if it should run on every update, or a specific one for a one-time fixup.
+
+!!! warning "Live registered objects aren't files"
+    Copier's diffing can only ever touch what's on disk. Azure Pipeline registrations are the concrete example here: `_tasks` only ever runs on a fresh `copier copy`, never on `update`, and no amount of file-diffing reaches something that only exists as a remote API object. Rename the file and the ordinary template-diff handles it correctly, but the *registration* in Azure DevOps has no idea that happened, and needs a dedicated migration script (see `migrate_pipeline_names.py`'s own docstring for the full reasoning) that repoints the existing registration in place (preserving its ID, run history, and any manually-set variables) rather than losing them to a delete-and-recreate.
+
+### Testing what you add
+
+Two different things need testing, and conflating them hides gaps: does the *template* render correctly, and does the *thing it produces* actually work?
+
+#### Template-level tests
+
+These validate the Copier mechanics themselves (the questions, the conditionals, the CI/CD scaffolding), independent of whatever domain-specific content you've layered on top. Three layers, each catching a different class of problem:
+
+- **`pytest tests/`** (fast, local, no external side effects): structural validation across the whole answer matrix: valid Jinja/YAML/JSON, no broken internal links, config/content consistency. Runs on every PR. This is where a new `ANSWER_MATRIX` entry or a new `validator:` gets exercised.
+- **Live integration testing** (`integration_test_github.py`/`-azdo.py` equivalents): actually creates a real throwaway repo and runs real pipelines/workflows against it. This is the only way to catch a regression in anything that needs a real API call, a real running pipeline, or a real external system's behavior, exactly the class of thing a local render can't exercise. Run before cutting a release, not on every PR.
+- **Manual verification checklists**: what's left after both of the above; human judgment (does this actually look right) and systems that can't be inspected programmatically (did a notification actually land at the configured endpoint, did a third-party bot actually respond).
+
+A change that only touches the first layer is untested in the ways that matter most for CI/CD scaffolding; prefer verifying against a real platform whenever what you're touching can plausibly break there.
+
+#### Tests for what the template produces
+
+This template has no workload of its own to test: it's pure scaffolding. Yours does: a Python library template produces Python libraries, a Terraform template produces Terraform configs, and whatever domain-specific content you add needs its own kind of verification, on top of (not instead of) the template-level layers above:
+
+- If the template ships starter or example code (a sample module, a sample stack), that code should pass its own domain's normal checks: run its actual test suite, linter, and type checker, not just confirm the files rendered without a Jinja error. A render that produces syntactically valid but broken starter code will sail through every template-level test and still hand a new user a project that fails on first run.
+- Any CI workflow or pipeline you add to exercise the workload itself (running the generated project's test suite, linting, `terraform validate`, etc.) goes through the same [Adding a new CI workflow or pipeline](#adding-a-new-ci-workflow-or-pipeline) checklist as anything else; it just validates the produced code instead of the template.
+- Where the domain has its own dependency or tooling ecosystem (a language's package manager, a linter, a language server), the [Adding a new versioned dependency or tool](#adding-a-new-versioned-dependency-or-tool) checklist applies there too; Renovate coverage doesn't stop at the template's own tooling.

--- a/template/{% if is_template %}scripts{% endif %}/template_docs_server.py
+++ b/template/{% if is_template %}scripts{% endif %}/template_docs_server.py
@@ -1,0 +1,686 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "rich==15.0.0",
+#     "tomlkit==0.15.1",
+#     "watchdog==6.0.0",
+# ]
+# ///
+
+"""Preview template/'s docs through a real zensical render.
+
+A template project's docs can be gated by `{% if %}` conditionals both in their
+path (e.g. `template/{% if is_template %}docs{% endif %}/`) and in their content
+(a `.md.jinja` file with an `{% if is_public %}...{% endif %}` paragraph). Thus,
+there's no single "correct" answer set to render the whole docs/ tree with.
+
+So instead of picking one answer set, this renders the whole tree once per entry
+in tests/answer_matrix.py's ANSWER_MATRIX (the same curated, valid combinations
+the render-validation suite itself tests against), run in parallel: each entry's
+a real `copier copy` subprocess call, releasing the GIL while it waits. Rather
+than assume a fixed axis like this project's own project_type (a downstream
+template can rename it, add values, or drop it), renders are grouped by what
+they actually produced: any two whose docs/ end up with the exact same set of
+files are the same "shape" and share one labeled top-level nav section, built
+from that shape's own real nav (theme, CSS, JS unmodified); a page whose content
+still differs *within* a shape gets its own nav entry expanded into labeled
+sibling pages. This project's own Template and Standard project_types are one
+example of two shapes, not an assumption baked into how shapes get found.
+
+This script watches all *docs* source directories the whole time it runs and
+re-renders on every save, so `zensical serve`'s own live-reload refreshes the
+browser.
+
+Run via `uv run` (its PEP 723 header above pulls in rich, tomlkit, and watchdog)
+rather than plain `python`, since none of the three are otherwise a project
+dependency.
+"""
+
+import argparse
+import importlib.util
+import re
+import shutil
+
+# S404: drives real CLI tools below; no untrusted input, no shell=True.
+import subprocess  # noqa: S404
+import sys
+import tempfile
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+# ty can't yet resolve a PEP 723 script's own inline deps (astral-sh/ty#4324), uv
+# run installs these correctly at execution time regardless.
+import tomlkit  # ty: ignore[unresolved-import]
+from rich.console import Console  # ty: ignore[unresolved-import]
+from watchdog.events import (  # ty: ignore[unresolved-import]
+    FileSystemEvent,
+    FileSystemEventHandler,
+)
+from watchdog.observers import Observer  # ty: ignore[unresolved-import]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE_DIR = REPO_ROOT / "template"
+ANSWER_MATRIX_FILE = REPO_ROOT / "tests" / "answer_matrix.py"
+
+console = Console()
+
+IGNORE_PATTERNS = shutil.ignore_patterns("__pycache__", ".cache")
+
+# How long the watched directories must go quiet before a save triggers a
+# re-render, and how often the watch loop checks for that. Some editors fire more
+# than one filesystem event per save (a write, then a rename for an atomic save):
+# debouncing coalesces those into one re-render instead of several overlapping
+# ones. Also long enough to collapse a burst of autosave-on-pause events while
+# actively typing into one render, without making a single deliberate edit wait
+# an unreasonably long time to see its result.
+DEBOUNCE_SECONDS = 5.0
+POLL_SECONDS = 0.1
+
+# Matches a whole Jinja tag ("{% if is_template %}", "{% endif %}", "{# ... #}"),
+# never a partial one: this template's own convention gates a whole path segment
+# at a time, never part of a name, so stripping every tag leaves exactly the literal
+# name a "true" render would produce.
+JINJA_TAG = re.compile(r"\{[%#].*?[%#]\}")
+
+
+class PreviewBuildError(Exception):
+    """No ANSWER_MATRIX entry could render a usable preview."""
+
+
+def run(
+    *args: str, cwd: Path | None = None, capture: bool = False, quiet: bool = False
+) -> subprocess.CompletedProcess:
+    """Run a CLI command, echoing it first unless `quiet`.
+
+    Resolves argv[0] via shutil.which() first: some CLIs are wrapped in ways that
+    subprocess with shell=False won't find from the bare name alone on every
+    platform.
+
+    Returns:
+        The completed process, with captured stdout/stderr merged if `capture`.
+
+    """
+    if not quiet:
+        console.print(f"$ {' '.join(args)}" + (f"  (in {cwd})" if cwd else ""))
+    resolved = (shutil.which(args[0]) or args[0], *args[1:])
+    stdout = subprocess.PIPE if capture else None
+    stderr = subprocess.STDOUT if capture else None
+    # S603: args are always a fixed list built by this module; no shell=True.
+    return subprocess.run(  # noqa: S603
+        resolved, check=True, cwd=cwd, stdout=stdout, stderr=stderr, text=True
+    )
+
+
+def load_answer_matrix() -> list[dict]:
+    """Load ANSWER_MATRIX from tests/answer_matrix.py without touching sys.path.
+
+    Returns:
+        The list of curated, valid answer-matrix entries.
+
+    Raises:
+        SystemExit: if tests/answer_matrix.py can't be loaded at all.
+
+    """
+    spec = importlib.util.spec_from_file_location("answer_matrix", ANSWER_MATRIX_FILE)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"Could not load {ANSWER_MATRIX_FILE}.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.ANSWER_MATRIX
+
+
+def find_docs_source_dirs() -> list[Path]:
+    """Locate every docs source directory directly under template/.
+
+    There can be more than one: this project's own template/ has a directory
+    gated on is_template and a separate, much smaller one gated on is_standard for
+    the other project_type. Matched purely by each directory's own name stripping
+    down to "docs" once its Jinja conditional is removed (doesn't need to know
+    what condition or axis is actually gating it, or what values it takes), so
+    this generalizes to whatever a downstream template ends up using for the same
+    purpose, not just this project's own project_type/is_template/is_standard.
+
+    Returns:
+        Every "docs"-shaped directory found.
+
+    """
+    return [
+        child
+        for child in TEMPLATE_DIR.iterdir()
+        if child.is_dir() and JINJA_TAG.sub("", child.name) == "docs"
+    ]
+
+
+def render_variant(entry: dict, dest: Path) -> None:
+    """Render template/ once using one ANSWER_MATRIX entry's answers, into `dest`.
+
+    Mirrors tests/conftest.py's own `-d key=value` invocation for ANSWER_MATRIX
+    entries, so this exercises the exact same copier invocation the render-
+    validation suite already trusts.
+    """
+    src = Path(tempfile.mkdtemp(prefix="tdsrc-"))
+    try:
+        shutil.copytree(TEMPLATE_DIR, src / "template", ignore=IGNORE_PATTERNS)
+        shutil.copy2(REPO_ROOT / "copier.yml", src / "copier.yml")
+        data_args = [
+            arg
+            for key, value in entry.items()
+            if key not in ("id", "_old_tag_overrides")
+            for arg in ("-d", f"{key}={value}")
+        ]
+        run(
+            "copier",
+            "copy",
+            "--trust",
+            "--defaults",
+            "--overwrite",
+            "--skip-tasks",
+            *data_args,
+            str(src),
+            str(dest),
+            capture=True,
+            quiet=True,
+        )
+    finally:
+        shutil.rmtree(src, ignore_errors=True)
+
+
+def render_all_variants() -> tuple[list[tuple[dict, Path]], list[str]]:
+    """Render the whole template/ tree once per ANSWER_MATRIX entry, in parallel.
+
+    Each render is a full site, kept around under its own temp dest; the caller
+    is responsible for cleaning those up once it's done reading from them.
+
+    Returns:
+        (successful (entry, dest) pairs in ANSWER_MATRIX order, error messages from
+        entries that failed to render at all).
+
+    """
+    matrix = load_answer_matrix()
+
+    def _one(entry: dict) -> tuple[dict, Path] | str:
+        """Render one entry.
+
+        Returns:
+            (entry, dest) on success, or an error string if the render failed.
+
+        """
+        dest = Path(tempfile.mkdtemp(prefix="tdvariant-"))
+        try:
+            render_variant(entry, dest)
+        except subprocess.CalledProcessError as exc:
+            shutil.rmtree(dest, ignore_errors=True)
+            return f"{entry['id']}:\n{exc.output}"
+        return (entry, dest)
+
+    # map() yields results in matrix order regardless of completion order, which
+    # keeps "the first applicable entry" (used to pick each section's primary
+    # render) deterministic across runs rather than a race between the render
+    # subprocesses.
+    with ThreadPoolExecutor(max_workers=len(matrix)) as pool:
+        results = list(pool.map(_one, matrix))
+
+    renders = [r for r in results if isinstance(r, tuple)]
+    errors = [r for r in results if isinstance(r, str)]
+    return renders, errors
+
+
+@dataclass
+class Variant:
+    """One ANSWER_MATRIX entry's rendered take on a target file."""
+
+    entry: dict
+    dest: Path
+    content: str
+
+
+def variants_for_path(
+    renders: list[tuple[dict, Path]], docs_rel: Path
+) -> list[Variant]:
+    """Check `docs_rel` across every already-rendered tree, relative to render root.
+
+    Returns:
+        A Variant for each render that actually has this file.
+
+    """
+    variants = []
+    for entry, render_dest in renders:
+        target = render_dest / docs_rel
+        if target.is_file():
+            content = target.read_text(encoding="utf-8")
+            variants.append(Variant(entry, render_dest, content))
+    return variants
+
+
+def dedupe_variants(variants: list[Variant]) -> list[list[Variant]]:
+    """Group variants that rendered identically, in ANSWER_MATRIX order.
+
+    Returns:
+        Groups of variants sharing identical content, in the order their content
+        was first seen.
+
+    """
+    groups: dict[str, list[Variant]] = {}
+    order: list[str] = []
+    for variant in variants:
+        if variant.content not in groups:
+            groups[variant.content] = []
+            order.append(variant.content)
+        groups[variant.content].append(variant)
+    return [groups[key] for key in order]
+
+
+def secondary_page_path(candidate_rel: Path, entry_id: str) -> Path:
+    """Path for a non-primary variant's page, distinguished by matrix entry id.
+
+    Returns:
+        The distinguished path, alongside `candidate_rel` in the same directory.
+
+    """
+    return candidate_rel.with_name(
+        f"{candidate_rel.stem}--{entry_id}{candidate_rel.suffix}"
+    )
+
+
+def collect_nav_leaves(nav_node: object, leaves: set[str]) -> None:
+    """Collect every plain path string referenced anywhere in a nav structure."""
+    if isinstance(nav_node, str):
+        leaves.add(nav_node)
+    elif isinstance(nav_node, list):
+        for item in nav_node:
+            collect_nav_leaves(item, leaves)
+    elif isinstance(nav_node, dict):
+        for value in nav_node.values():
+            collect_nav_leaves(value, leaves)
+
+
+def expand_nav_variants(
+    nav_node: object, variant_pages: dict[str, list[dict[str, str]]]
+) -> object:
+    """Recursively rebuild `nav_node`, expanding any leaf path that has variants.
+
+    A leaf whose path is a key in `variant_pages` is replaced by its list of
+    `{label: path}` entries, spliced into the surrounding list in its place;
+    everything else in the nav is left exactly as the primary render authored it.
+
+    Returns:
+        The rebuilt nav node.
+
+    """
+    if isinstance(nav_node, str):
+        return variant_pages.get(nav_node, nav_node)
+    if isinstance(nav_node, list):
+        result: list[object] = []
+        for item in nav_node:
+            expanded = expand_nav_variants(item, variant_pages)
+            if isinstance(expanded, list):
+                result.extend(expanded)
+            else:
+                result.append(expanded)
+        return result
+    if isinstance(nav_node, dict):
+        return {
+            key: expand_nav_variants(value, variant_pages)
+            for key, value in nav_node.items()
+        }
+    return nav_node
+
+
+def read_nav(render_dest: Path) -> object:
+    """Read a rendered site's own nav, straight from its own zensical.toml.
+
+    Returns:
+        The parsed nav array.
+
+    """
+    zensical_toml = render_dest / "zensical.toml"
+    doc = tomlkit.parse(zensical_toml.read_text(encoding="utf-8"))
+    return doc["project"]["nav"]
+
+
+def prefix_nav_paths(nav_node: object, prefix: Path) -> object:
+    """Recursively rebuild `nav_node` with every leaf path prefixed by `prefix`.
+
+    Returns:
+        The rebuilt nav node.
+
+    """
+    if isinstance(nav_node, str):
+        return (prefix / nav_node).as_posix()
+    if isinstance(nav_node, list):
+        return [prefix_nav_paths(item, prefix) for item in nav_node]
+    if isinstance(nav_node, dict):
+        return {key: prefix_nav_paths(value, prefix) for key, value in nav_node.items()}
+    return nav_node
+
+
+def build_section(
+    dest: Path, type_renders: list[tuple[dict, Path]], path_prefix: Path | None
+) -> object:
+    """Build one project_type's nav section, writing its pages under `path_prefix`.
+
+    `type_renders` must already be filtered to a single project_type, in
+    ANSWER_MATRIX order. `path_prefix` relocates every page under it (relative to
+    docs_dir) so this section's pages don't collide with another section sharing
+    the same `dest`; pass None only for the one section whose relative links
+    were authored assuming they sit at docs_dir's own root: this template's own
+    Template-type docs cross-reference each other extensively with plain relative
+    links like "releasing.md" or "../index.md#..." (prefixing them without also
+    rewriting every link target breaks every one of those, confirmed: zensical's
+    own build reported "page does not exist" for exactly these links the first
+    time every section got prefixed uniformly).
+
+    Returns:
+        This section's nav: the first applicable render's own real nav, prefixed
+        if `path_prefix` is given, with any page that varies expanded into
+        labeled sibling pages.
+
+    """
+    _primary_entry, primary_dest = type_renders[0]
+    original_nav = read_nav(primary_dest)
+
+    if path_prefix is None:
+        shutil.copytree(primary_dest / "docs", dest / "docs", dirs_exist_ok=True)
+
+    leaves: set[str] = set()
+    collect_nav_leaves(original_nav, leaves)
+
+    variant_pages: dict[str, list[dict[str, str]]] = {}
+    for nav_path in leaves:
+        docs_rel = Path("docs") / nav_path
+        target_nav_path = (
+            (path_prefix / nav_path).as_posix() if path_prefix else nav_path
+        )
+        groups = dedupe_variants(variants_for_path(type_renders, docs_rel))
+        if not groups:
+            continue  # Shouldn't happen: primary's own nav references it.
+        if len(groups) == 1:
+            if path_prefix is not None:
+                # Nothing pre-populated `dest` at a prefixed location the way the
+                # unprefixed case's copytree above already covers.
+                page_rel = Path("docs") / target_nav_path
+                (dest / page_rel).parent.mkdir(parents=True, exist_ok=True)
+                (dest / page_rel).write_text(groups[0][0].content, encoding="utf-8")
+            continue
+        entries = []
+        for group in groups:
+            representative = group[0]
+            if path_prefix is None and representative.dest == primary_dest:
+                page_rel = docs_rel  # Already synced above.
+            else:
+                variant_rel = secondary_page_path(
+                    Path(target_nav_path), representative.entry["id"]
+                )
+                page_rel = Path("docs") / variant_rel
+                (dest / page_rel).parent.mkdir(parents=True, exist_ok=True)
+                (dest / page_rel).write_text(representative.content, encoding="utf-8")
+            entries.append(
+                {representative.entry["id"]: page_rel.relative_to("docs").as_posix()}
+            )
+        variant_pages[target_nav_path] = entries
+
+    nav = (
+        original_nav
+        if path_prefix is None
+        else prefix_nav_paths(original_nav, path_prefix)
+    )
+    return expand_nav_variants(nav, variant_pages)
+
+
+def docs_fingerprint(render_dest: Path) -> frozenset[str]:
+    """Compute the set of relative paths under a render's docs/, its "shape".
+
+    Returns:
+        A hashable set of docs-relative paths (empty if there's no docs/ at all).
+
+    """
+    docs_dir = render_dest / "docs"
+    if not docs_dir.is_dir():
+        return frozenset()
+    return frozenset(
+        str(p.relative_to(docs_dir)) for p in docs_dir.rglob("*") if p.is_file()
+    )
+
+
+def group_by_docs_shape(
+    renders: list[tuple[dict, Path]],
+) -> list[list[tuple[dict, Path]]]:
+    """Group renders whose docs/ trees have the exact same set of files.
+
+    Different answer combinations can produce structurally different docs/ trees
+    (this project's own template/ has an is_template docs source and a completely
+    separate, smaller is_standard one); rather than hardcode which answer (e.g.
+    project_type) drives that, or what its values are called, this groups purely
+    by what each render actually produced. Whatever axis a downstream template
+    ends up using for the same purpose (however many values, whatever they're
+    named) falls out of this for free. Two renders sharing a shape but differing
+    in per-page *content* still land in the same group here; that's exactly what
+    build_section()'s own per-page variant expansion is for.
+
+    Returns:
+        Groups of (entry, dest) pairs sharing an identical docs/ file set, in the
+        order each shape was first seen (ANSWER_MATRIX order).
+
+    """
+    groups: dict[frozenset[str], list[tuple[dict, Path]]] = {}
+    order: list[frozenset[str]] = []
+    for entry, render_dest in renders:
+        shape = docs_fingerprint(render_dest)
+        if shape not in groups:
+            groups[shape] = []
+            order.append(shape)
+        groups[shape].append((entry, render_dest))
+    return [groups[key] for key in order]
+
+
+def section_label(type_renders: list[tuple[dict, Path]], index: int) -> str:
+    """Build a human label for one docs-shape group's nav section.
+
+    Returns:
+        `"<project_type> Project"` if every render in this group agrees on a
+        project_type answer (whatever it's actually called downstream), else a
+        generic positional fallback for a template that doesn't have one.
+
+    """
+    types = {entry.get("project_type") for entry, _ in type_renders}
+    if len(types) == 1:
+        (project_type,) = types
+        if project_type:
+            return f"{project_type} Project"
+    return f"Docs ({index + 1})"
+
+
+def assemble_whole_tree(dest: Path, renders: list[tuple[dict, Path]]) -> None:
+    """Build one nav section per distinct docs "shape" found in `renders`.
+
+    The theme/CSS/JS/etc. from whichever render happens to be first becomes
+    `dest`'s shared assets; those don't vary by shape. Each distinct shape gets
+    its own labeled top-level nav group, built from that group's own real nav
+    with any page whose content varies within the group expanded into labeled
+    sibling pages (see group_by_docs_shape()'s docstring for why shape, not a
+    hardcoded answer key, is what defines a section).
+
+    The first shape found (ANSWER_MATRIX order) is left unprefixed, since this
+    project's own docs cross-reference each other with plain relative links (see
+    build_section()'s docstring) and prefixing breaks those; every other shape is
+    prefixed to avoid colliding with it.
+    """
+    shutil.copytree(renders[0][1], dest, dirs_exist_ok=True)
+
+    sections = []
+    for index, shape_renders in enumerate(group_by_docs_shape(renders)):
+        path_prefix = None if index == 0 else Path(f"docs-{index + 1}")
+        section_nav = build_section(dest, shape_renders, path_prefix)
+        sections.append({section_label(shape_renders, index): section_nav})
+
+    zensical_toml = dest / "zensical.toml"
+    doc = tomlkit.parse(zensical_toml.read_text(encoding="utf-8"))
+    doc["project"]["nav"] = sections
+    zensical_toml.write_text(tomlkit.dumps(doc), encoding="utf-8")
+
+
+def build_whole_tree_preview(dest: Path) -> None:
+    """Render the whole docs/ tree under every ANSWER_MATRIX entry into `dest`.
+
+    Raises:
+        PreviewBuildError: if every ANSWER_MATRIX entry failed to render outright.
+
+    """
+    renders, errors = render_all_variants()
+    try:
+        if not renders:
+            detail = "\n".join(errors) if errors else "every entry failed to render."
+            raise PreviewBuildError(f"Could not render any preview:\n{detail}")
+        assemble_whole_tree(dest, renders)
+    finally:
+        for _, render_dest in renders:
+            shutil.rmtree(render_dest, ignore_errors=True)
+
+
+def render_with_status(dest: Path, label: str) -> bool:
+    """Build the preview behind a spinner, printing a one-line pass/fail summary.
+
+    Returns:
+        True if the build succeeded. False if it failed, with the error output
+        already printed; the caller decides whether that's fatal.
+
+    """
+    start = time.perf_counter()
+    try:
+        with console.status(f"{label} ..."):
+            build_whole_tree_preview(dest)
+    except (subprocess.CalledProcessError, PreviewBuildError) as exc:
+        elapsed = time.perf_counter() - start
+        console.print(f"[red]✗ FAILED:[/red] {label} (after {elapsed:.1f}s):")
+        is_subprocess_error = isinstance(exc, subprocess.CalledProcessError)
+        detail = exc.output if is_subprocess_error else str(exc)
+        # markup=False: this can contain copier's own captured output, not trusted
+        # text; it can contain literal "[...]" (e.g. "[Errno 2]") that isn't rich
+        # markup.
+        console.print(detail, markup=False)
+        return False
+    elapsed = time.perf_counter() - start
+    console.print(f"[green]✓ OK:[/green] {label} ({elapsed:.1f}s)")
+    return True
+
+
+def start_zensical(dest: Path, extra_args: list[str]) -> subprocess.Popen:
+    """Start `zensical serve` in the background against `dest`.
+
+    Returns:
+        The running process; the caller is responsible for terminating it.
+
+    """
+    args = ["zensical", "serve", *extra_args]
+    console.print(f"$ {' '.join(args)}  (in {dest})")
+    resolved = (shutil.which(args[0]) or args[0], *args[1:])
+    # S603: fixed argv, no shell=True.
+    return subprocess.Popen(resolved, cwd=dest)  # noqa: S603
+
+
+class ChangeHandler(FileSystemEventHandler):
+    """Records the time of the most recent change under any watched directory."""
+
+    def __init__(self, watch_dirs: list[Path]) -> None:
+        """Watch `watch_dirs`; start out with no change recorded."""
+        super().__init__()
+        self._dirs = watch_dirs
+        self.last_change_at: float | None = None
+
+    def on_any_event(self, event: FileSystemEvent) -> None:
+        """Record a change, ignoring anything outside the watched directories."""
+        if event.is_directory:
+            return
+        changed = Path(event.src_path).resolve()
+        if any(changed.is_relative_to(watch_dir) for watch_dir in self._dirs):
+            self.last_change_at = time.monotonic()
+
+
+def watch_and_rerender(
+    dest: Path, handler: ChangeHandler, stop: threading.Event
+) -> None:
+    """Rebuild `dest` on each settled change `handler` reports, until `stop` fires."""
+    while not stop.is_set():
+        changed_at = handler.last_change_at
+        if changed_at is not None and time.monotonic() - changed_at >= DEBOUNCE_SECONDS:
+            handler.last_change_at = None
+            console.print("\n⟳ Change detected")
+            render_with_status(dest, "Re-rendering")
+        stop.wait(POLL_SECONDS)
+
+
+def main() -> None:
+    """Preview docs, live-reloading on every save, until stopped.
+
+    Raises:
+        SystemExit: with code 1, if the very first build fails; there's nothing
+            to serve yet, so that's fatal (unlike a later rebuild triggered by a
+            change, which just keeps serving the last good version).
+
+    """
+    # sys.stdout is typed as TextIO, which doesn't declare reconfigure(): it's a
+    # real TextIOWrapper at runtime, though. Without this, Windows' default console
+    # codepage (cp1252) can't encode the status glyphs below (rich hits the same
+    # UnicodeEncodeError regardless of which internal render path it takes, since
+    # both end up calling sys.stdout.write() directly). Assumes whoever runs this has
+    # a Unicode-capable terminal.
+    sys.stdout.reconfigure(encoding="utf-8")  # ty: ignore[unresolved-attribute]
+
+    parser = argparse.ArgumentParser(
+        description="Preview template/'s docs through a real zensical render."
+    )
+    _args, zensical_args = parser.parse_known_args()
+
+    watch_dirs = find_docs_source_dirs()
+    if not watch_dirs:
+        raise SystemExit(f"Could not find a docs/ source dir under {TEMPLATE_DIR}.")
+    for docs_dir in watch_dirs:
+        console.print(f"Previewing {docs_dir.relative_to(TEMPLATE_DIR)}")
+
+    dest = Path(tempfile.mkdtemp(prefix="tdout-"))
+    if not render_with_status(dest, "Rendering initial preview"):
+        shutil.rmtree(dest, ignore_errors=True)
+        raise SystemExit(1)
+
+    server = start_zensical(dest, zensical_args)
+
+    handler = ChangeHandler(watch_dirs)
+    observer = Observer()
+    for watch_dir in watch_dirs:
+        observer.schedule(handler, str(watch_dir), recursive=True)
+    observer.start()
+
+    stop = threading.Event()
+    watcher = threading.Thread(
+        target=watch_and_rerender, args=(dest, handler, stop), daemon=True
+    )
+    watcher.start()
+
+    watched = ", ".join(str(watch_dir) for watch_dir in watch_dirs)
+    console.print(
+        f"\nWatching {watched}: saves re-render and live-reload automatically. "
+        "Press Ctrl+C to stop.\n"
+    )
+
+    try:
+        server.wait()
+    except KeyboardInterrupt:
+        console.print("\nStopping ...")
+    finally:
+        stop.set()
+        watcher.join(timeout=2)
+        observer.stop()
+        observer.join(timeout=2)
+        server.terminate()
+        try:
+            server.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            server.kill()
+        shutil.rmtree(dest, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds template/docs/extending-the-template.md: a guide for downstream template authors covering the fork between leaf and extensible templates, and the checklists for adding dependencies, Copier questions, CI workflows, secrets, and renames.

Also adds `mise run template-docs-server`, which renders the whole docs/ tree once per tests/answer_matrix.py entry (in parallel) and builds one real zensical site per distinct docs "shape". No single answer set renders every doc correctly, since both file paths and page content can be Jinja-conditional; this shows every combination that actually produces different output instead of guessing one.