### PR TITLE
style: remove stylistic double hyphens from docs and comments

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -27,7 +27,7 @@ parent_template_url:
 ## Start Migrations
 _migrations:
   # release-please wrote CHANGELOG.md headings as `## [X.Y.Z](url) (date)`, which
-  # Knope's changelog writer can't parse -- it silently appends new releases at the
+  # Knope's changelog writer can't parse; it silently appends new releases at the
   # end of the file instead of the top once it can't find a heading it recognizes. A
   # project that adopted this template before the Knope switch has that same stale
   # formatting, so it needs the same one-time reformat this repo's own CHANGELOG.md
@@ -58,13 +58,13 @@ _migrations:
     version: v0.8.1
     when: "{{ _stage == 'after' }}"
 
-  # No `version:` -- this runs on every update, not just once, so upstream changes
-  # actually show up in this project's own changelog instead of vanishing into an
+  # This runs on every update, not on one version transition, so upstream changes
+  # show in this project's own changelog instead of vanishing into an
   # opaque "chore: apply parent template" commit. Computes the real bump/changelog
   # content by running Knope's own compute-upstream-bump workflow for real (not
   # --dry-run) inside a throwaway clone of the template, with every tag but this
   # project's old template version hidden so Knope's own "most recent tag" baseline
-  # lands on the actual delta -- see that workflow's comment in knope.toml for why.
+  # lands on the actual delta; see that workflow's comment in knope.toml for why.
   # Silently does nothing if there's no qualifying commit to bump (e.g. an
   # internal-only template change) or if the old version isn't a real tag in the
   # template's history.
@@ -239,7 +239,7 @@ developer_platform:
   help: |
     {%- if not project_initialized -%}
       The platform where you are going to host your Git repo and CI/CD. Azure DevOps
-      support is deprecated and will eventually be removed -- prefer GitHub unless you
+      support is deprecated and will eventually be removed; prefer GitHub unless you
       specifically need Azure DevOps.
     {%- else -%}
       Locked value on update, press Enter.
@@ -276,7 +276,7 @@ repo_setup_actions:
           {%- elif repo_setup_actions == 'Create Repo' -%}
             {%- set knope_check = ('knope --version && echo KNOPE_INSTALLED' | shell()) -%}
             {%- if 'KNOPE_INSTALLED' not in knope_check -%}
-              Knope ('knope') is not installed or not on PATH -- it's used to stage this project's first release. Install it (see https://knope.tech/), then try again.
+              Knope ('knope') is not installed or not on PATH. Install it (see https://knope.tech/), then try again.
             {%- endif -%}
           {%- endif -%}
         {%- endif -%}
@@ -295,7 +295,7 @@ repo_setup_actions:
             {%- elif repo_setup_actions == 'Create Repo' -%}
               {%- set knope_check = ('knope --version && echo KNOPE_INSTALLED' | shell()) -%}
               {%- if 'KNOPE_INSTALLED' not in knope_check -%}
-                Knope ('knope') is not installed or not on PATH -- it's used to stage this project's first release. Install it (see https://knope.tech/), then try again.
+                Knope ('knope') is not installed or not on PATH. Install it (see https://knope.tech/), then try again.
               {%- endif -%}
             {%- endif -%}
           {%- endif -%}
@@ -456,7 +456,7 @@ lifecycle:
   validator: |-
     {%- set _rank = {"Pre-Alpha": 0, "Alpha": 1, "Beta": 2, "Stable": 3} -%}
     {%- if lifecycle_previous in _rank and lifecycle in _rank and _rank[lifecycle] < _rank[lifecycle_previous] -%}
-      Can't move from '{{ lifecycle_previous }}' back to '{{ lifecycle }}' -- lifecycle only moves forward (Pre-Alpha -> Alpha -> Beta -> Stable). 'Inactive' is a separate state, reachable from any of these.
+      Can't move from '{{ lifecycle_previous }}' back to '{{ lifecycle }}': lifecycle only moves forward (Pre-Alpha -> Alpha -> Beta -> Stable). 'Inactive' is a separate state, reachable from any of these.
     {%- endif -%}
 
 agent_instructions:
@@ -466,7 +466,7 @@ agent_instructions:
 
 code_coverage:
   type: bool
-  help: Report code coverage via Codecov (GitHub) or Azure Pipelines' built-in publishing (Azure DevOps) -- wires up reporting only, your test command needs to produce coverage.xml (Cobertura) at the repo root.
+  help: Report code coverage via Codecov (GitHub) or Azure Pipelines' built-in publishing (Azure DevOps). This wires up reporting only, your test command needs to produce coverage.xml (Cobertura) at the repo root.
   default: false
 ## End Questions
 
@@ -602,10 +602,10 @@ current_knope_version_is_pre_1:
 setup_checklist:
   type: str
   default: |-
-    - [ ] Add more badges to the top of README.md, or remove that section.
+    - [ ] Add/remove badges to the top of README.md.
     - [ ] Replace docs/images/readme-logo.png with your own logo, or remove that section from README.md.
     - [ ] Replace docs/images/readme-screenshot.png with a real screenshot of your project, or remove that section from README.md.
-    - [ ] Set required secrets/pipeline variables -- run `mise run provision-secrets` or see docs/token-permissions.md.
+    - [ ] Set required secrets/pipeline variables: run `mise run provision-secrets` or see docs/token-permissions.md.
   when: false
 ## End Post-Question Computed Values
 
@@ -772,7 +772,7 @@ _tasks:
     when: *when_copy_set_repo_settings_azdo
 
   # A freshly-registered AzDO YAML pipeline's push-based CI trigger doesn't reliably
-  # activate until the pipeline has run at least once -- confirmed via live testing (a
+  # activate until the pipeline has run at least once; confirmed via live testing (a
   # real push produced zero pipeline runs until a manual run was queued first). This
   # one-time warm-up run activates it for every push after.
   - command: >-
@@ -798,7 +798,7 @@ _tasks:
   # Requires the pr_validation build to pass before a PR can be completed, and lets
   # Project Administrators override that when completing a PR (mirrors GitHub's
   # admin bypass_actors entry in settings.yml.jinja). `az repos policy` has no flag
-  # for the override part -- it's a branch-level security permission instead, set
+  # for the override part; it's a branch-level security permission instead, set
   # via the raw security-namespace API since `az repos`/`az devops` has no
   # higher-level command for it. Namespace ID, permission bit, and token format
   # aren't in Microsoft's own CLI docs; cross-checked against
@@ -812,7 +812,7 @@ _tasks:
 
         ORG = "https://dev.azure.com/{{ azdo_org }}/"
         PROJECT = "{{ azdo_project }}"
-        # az is an az.cmd batch wrapper on Windows, not a real .exe -- subprocess with
+        # az is an az.cmd batch wrapper on Windows, not a real .exe; subprocess with
         # shell=False (the default, used throughout below) won't find it from the bare
         # name alone, failing with FileNotFoundError: [WinError 2]. which() finds the
         # actual resolvable path on any platform, sidestepping that gap without
@@ -860,7 +860,7 @@ _tasks:
             for g in groups["graphGroups"]
             if g["displayName"] == "Project Administrators"
         )
-        # refs/heads/main, UTF-16LE hex-encoded per character -- Azure DevOps's Git
+        # refs/heads/main, UTF-16LE hex-encoded per character; Azure DevOps's Git
         # ACL token format for a specific branch.
         token = f"repoV2/{project_id}/{repo_id}/refs/heads/6d00610069006e00"
         subprocess.run(
@@ -917,7 +917,7 @@ _tasks:
         true
       {%- endif %}
 
-  # Enables CodeQL code scanning's default setup -- free for public repos, needs
+  # Enables CodeQL code scanning's default setup; free for public repos, needs
   # GitHub Advanced Security (paid) on private ones, so scoped to public only.
   - command: >-
       gh api repos/{{ github_repo_owner }}/{{ repo_name }}/code-scanning/default-setup
@@ -928,7 +928,7 @@ _tasks:
       {%- endif %}
 
   # Lets anyone privately report a security vulnerability (Security > Advisories)
-  # instead of only via a public issue -- meaningful for public repos specifically,
+  # instead of only via a public issue; meaningful for public repos specifically,
   # since a private repo's issues are already restricted to invited collaborators.
   - command: gh api repos/{{ github_repo_owner }}/{{ repo_name }}/private-vulnerability-reporting -X PUT
     when: *when_copy_public_github
@@ -972,11 +972,11 @@ _message_after_copy: |-
   {%- if code_coverage %}
     - CODECOV_TOKEN
   {%- endif %}
-  Run `mise run provision-secrets` for a guided, masked prompt, or set them by hand -- see docs/token-permissions.md for what each one needs.
+  Run `mise run provision-secrets`, or see docs/token-permissions.md for manual provisioning details.
   {%- elif using_azdo -%}
   Before CI works, add these as secret Azure DevOps pipeline variables (Pipelines > Library):
     - APPRISE_URL
-  Run `mise run provision-secrets` for a guided, masked prompt, or set them by hand -- see docs/token-permissions.md for what each one needs.
+  Run `mise run provision-secrets`, or see docs/token-permissions.md for manual provisioning details.
   {%- endif %}
 
 _message_after_update: |-

--- a/renovate.json
+++ b/renovate.json
@@ -178,7 +178,7 @@
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
     },
     {
-      "description": "Manager for the knope mise tool pin -- knope-dev/knope is a monorepo that tags each crate's releases separately (e.g. knope/vX.Y.Z), so the generic \"simple mise tools\" manager above can't be used: extractVersionTemplate is what filters the mixed-prefix tags down to just knope's own",
+      "description": "Manager for the knope mise tool pin: knope-dev/knope is a monorepo that tags each crate's releases separately (e.g. knope/vX.Y.Z), so the generic \"simple mise tools\" manager above can't be used: extractVersionTemplate is what filters the mixed-prefix tags down to just knope's own",
       "customType": "regex",
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "knope-dev/knope",
@@ -267,7 +267,7 @@
       "versioningTemplate": "pep440"
     },
     {
-      "description": "Manager for npm-backed mise tools with options -- mirrors \"Manager for pipx tools with options\" above, but for the npm: backend prefix (datasource npm instead of pypi). A separate manager because that one's datasource is hardcoded to pypi.",
+      "description": "Manager for npm-backed mise tools with options: mirrors \"Manager for pipx tools with options\" above, but for the npm: backend prefix (datasource npm instead of pypi). A separate manager because that one's datasource is hardcoded to pypi.",
       "customType": "regex",
       "datasourceTemplate": "npm",
       "managerFilePatterns": [

--- a/template/.config/knope-current-version.json
+++ b/template/.config/knope-current-version.json
@@ -1,4 +1,4 @@
 {
-  "_comment": "Managed by Knope -- do not edit manually.",
+  "_comment": "Managed by Knope; do not edit manually.",
   "version": "0.0.0"
 }

--- a/template/.config/prek.toml.jinja
+++ b/template/.config/prek.toml.jinja
@@ -16,7 +16,7 @@ description = "Runs actionlint to lint GitHub Actions workflow files"
 language = "system"
 entry = "mise x -- actionlint"
 types = ["yaml"]
-# Also matches template/.../workflows/ -- a Template-type project embeds a full,
+# Also matches template/.../workflows/; a Template-type project embeds a full,
 # unrendered copy of template/ (via copy-template-files) for its own children to use,
 # regardless of *this* project's own developer_platform.
 files = "(^\\.github/workflows/|^template/.*workflows/)"
@@ -139,7 +139,7 @@ id = "fix-byte-order-marker"
 [[repos.hooks]]
 id = "mixed-line-ending"
 # Replaces a repo-wide `* text eol=lf` .gitattributes rule, which can corrupt binary
-# files (e.g. images) that Git's own text-detection heuristic misclassifies -- this
+# files (e.g. images) that Git's own text-detection heuristic misclassifies; this
 # hook's `types: [text]` filter (from pre-commit-hooks' own default) uses the more
 # reliable `identify` library instead, and never touches a file it can't confirm is text.
 args = ["--fix=lf"]

--- a/template/knope.toml.jinja
+++ b/template/knope.toml.jinja
@@ -55,7 +55,7 @@ command = "git push --tags"
 
 [[workflows]]
 # Used only by copier.yml's _migrations, inside a scratch clone of the template repo
-# with every tag but the project's old template version hidden -- PrepareRelease
+# with every tag but the project's old template version hidden; PrepareRelease
 # always bumps from "the most recent reachable tag", so hiding the rest is what makes
 # it compute the real delta across a multi-version jump instead of just the last hop.
 # Run for real (not --dry-run): the scratch clone is thrown away either way, and

--- a/template/mise.ci.toml.jinja
+++ b/template/mise.ci.toml.jinja
@@ -14,7 +14,7 @@ node = "24.19.0"
 [tools."npm:renovate"]
 version = "44.39.3"
 # @yarnpkg/libzip@3.2.2 (a renovate transitive dependency) lost the provenance
-# attestation an earlier published version (3.2.0) had -- mise's trust policy
+# attestation an earlier published version (3.2.0) had; mise's trust policy
 # flags that downgrade and refuses to install rather than risk a tampered
 # release. Narrowly excluded pending upstream investigation; remove once
 # resolved (tracked separately, not in this repo's own issue tracker).

--- a/template/mise.toml.jinja
+++ b/template/mise.toml.jinja
@@ -21,7 +21,7 @@ run = "copier update --answers-file .config/copier-answers.yml --skip-answered -
 [tasks.set-lifecycle]
 # Re-prompts just the `lifecycle` question (--ask overrides --skip-answered for it,
 # showing its normal choice menu with the current value pre-selected) without pulling
-# in a template update alongside it -- `--vcs-ref=:current:` pins the update to the
+# in a template update alongside it; `--vcs-ref=:current:` pins the update to the
 # currently-installed template version instead of the latest one. Both flags' minimum
 # copier versions are enforced by this project's own _min_copier_version.
 run = "copier update --answers-file .config/copier-answers.yml --skip-answered --trust --vcs-ref=:current: --ask lifecycle"
@@ -30,10 +30,10 @@ run = "copier update --answers-file .config/copier-answers.yml --skip-answered -
 run = "zensical serve"
 
 [tasks.provision-secrets]
-# Opt-in and separate from _tasks on purpose -- see docs/token-permissions.md. `raw`
+# Opt-in and separate from _tasks on purpose; see docs/token-permissions.md. `raw`
 # gives gh/az direct terminal control so each CLI's own masked prompt (gh's
 # Prompter.Password, az's knack.prompting.prompt_pass) reads the value straight from
-# the terminal -- it never touches a command-line argument, mise's own logging, or a
+# the terminal; it never touches a command-line argument, mise's own logging, or a
 # script of ours.
 raw = true
 run = [
@@ -54,7 +54,7 @@ run = [
 
 [tasks.migrate-azdo-pipeline-names]
 # One-time fixup for an *existing* project after a copier update that renamed
-# .azurepipelines/*.yml files -- see that script's own docstring for why this can't
+# .azurepipelines/*.yml files; see that script's own docstring for why this can't
 # just be a _tasks entry (those only ever run on a fresh `copier copy`).
 run = "python .azurepipelines/migrate_pipeline_names.py"
 {%- endif %}
@@ -74,18 +74,18 @@ run = "uv run scripts/template_docs_server.py"
 
 [tasks.integration-test-gh]
 # Creates two real throwaway repos from this template and runs every automated check
-# it can against Repo A, always at HEAD -- this exists to verify a release candidate
+# it can against Repo A, always at HEAD; this exists to verify a release candidate
 # on main is good before cutting a release, not to smoke-test an arbitrary branch. See
 # docs/integration-testing.md for what this does and doesn't check, and
 # docs/manual-verification-github.md for what still needs a human. Repo B is copied at
-# the last stable tag and left there -- run `mise run copier-update` against it
+# the last stable tag and left there; run `mise run copier-update` against it
 # yourself, then `mise run integration-test-verify-update-gh` to verify it. Both repos
 # are left in place afterward for inspection; delete them yourself when you're done.
 run = "python scripts/integration_test_github.py --source https://github.com/{{ github_repo_owner }}/{{ repo_name }} --repo-prefix {{ repo_name }}"
 
 [tasks.integration-test-verify-update-gh]
 # Run after manually updating Repo B (see docs/manual-verification-github.md's "Repo
-# B" section) -- verifies the update applied cleanly (no conflict markers, current
+# B" section); verifies the update applied cleanly (no conflict markers, current
 # content) and that PR Validation still works, the same way integration-test-gh
 # already verifies Repo A.
 usage = '''
@@ -98,11 +98,11 @@ run = "python scripts/integration_test_github.py"
 {%- set org_default = azdo_org if using_azdo else '' %}
 {%- set project_default = azdo_project if using_azdo else '' %}
 # Creates two real throwaway repos from this template and runs every automated check
-# it can against Repo A, always at HEAD -- this exists to verify a release candidate
+# it can against Repo A, always at HEAD; this exists to verify a release candidate
 # on main is good before cutting a release, not to smoke-test an arbitrary branch. See
 # docs/integration-testing.md for what this does and doesn't check, and
 # docs/manual-verification-azdo.md for what still needs a human. Repo B is copied at
-# the last stable tag and left there -- run `mise run copier-update` (then `mise run
+# the last stable tag and left there; run `mise run copier-update` (then `mise run
 # migrate-azdo-pipeline-names`) against it yourself, then `mise run
 # integration-test-verify-update-azdo` to verify it. Both repos are left in place
 # afterward for inspection; delete them yourself when you're done. --org/--project
@@ -111,7 +111,7 @@ run = "python scripts/integration_test_github.py"
 # integration-test-azdo -- --org myorg --project myproject`. Uses the `usage` field
 # (not the deprecated option() Tera function) so these are passed to the script as
 # real env vars (usage_org/usage_project) rather than templated into the command line
-# -- works identically regardless of the invoking shell/platform, and (unlike
+# this works identically regardless of the invoking shell/platform, and (unlike
 # option()) a missing required value doesn't silently vanish from the command line and
 # desync argparse.
 usage = '''
@@ -122,7 +122,7 @@ run = "python scripts/integration_test_azdo.py --source {% if using_github %}htt
 
 [tasks.integration-test-verify-update-azdo]
 # Run after manually updating Repo B (see docs/manual-verification-azdo.md's "Repo B"
-# section) -- verifies the update applied cleanly (no conflict markers, current
+# section); verifies the update applied cleanly (no conflict markers, current
 # content, pipelines renamed in place) and that PR Validation still works, the same
 # way integration-test-azdo already verifies Repo A.
 usage = '''
@@ -150,7 +150,7 @@ actionlint = "1.7.12"
 {%- endif %}
 {%- if using_github %}
 {#- Used by _tasks in copier.yml for repo creation/setup. Note this doesn't help during
-   the questionnaire itself (this file doesn't exist yet at that point) -- the
+   the questionnaire itself (this file doesn't exist yet at that point); the
    developer_platform question's validator checks whatever gh is already on PATH. #}
 {#- renovate: datasource=github-releases depName=cli/cli #}
 "aqua:cli/cli" = "2.97.0"
@@ -159,9 +159,9 @@ actionlint = "1.7.12"
    workflows on both platforms. ubi is deprecated in mise and knope isn't in the aqua
    registry, so this uses the github backend directly. knope-dev/knope is a monorepo
    that tags each crate's releases separately (e.g. "knope/vX.Y.Z", not a bare
-   "vX.Y.Z") -- tracked by the dedicated "Manager for the knope mise tool pin"
+   "vX.Y.Z"); tracked by the dedicated "Manager for the knope mise tool pin"
    customManager in renovate.json.jinja, not the generic "simple mise tools" one,
-   since that can't filter a monorepo's mixed-prefix tags -- deliberately no
+   since that can't filter a monorepo's mixed-prefix tags; deliberately no
    `renovate:` comment marker here, since that generic manager would also match it. #}
 "github:knope-dev/knope" = "knope/v0.23.0"
 {#- renovate: datasource=github-releases depName=crate-ci/typos #}
@@ -194,7 +194,7 @@ uvx_args = "--with jinja2-shell-extension==2.1.1"
 version = "9.1.1"
 # pytest-github-actions-annotate-failures / pytest-azurepipelines surface pytest
 # failures and warnings as native platform annotations (::warning::/::error:: on
-# GitHub, ##vso[task.logissue] on Azure DevOps) with zero config -- they auto-detect
+# GitHub, ##vso[task.logissue] on Azure DevOps) with zero config; they auto-detect
 # their CI via the env vars each platform already sets.
 uvx_args = "--with pyyaml==6.0.3 --with jinja2==3.1.6 --with jinja2-ansible-filters==1.3.2 --with pytest-xdist==3.8.0{% if using_github %} --with pytest-github-actions-annotate-failures==0.4.2{% elif using_azdo %} --with pytest-azurepipelines==1.0.5{% endif %}"
 {%- endif %}

--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -200,7 +200,7 @@
       "versioningTemplate": {% raw %}"{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"{% endraw %}
     },
     {
-      "description": "Manager for the knope mise tool pin -- knope-dev/knope is a monorepo that tags each crate's releases separately (e.g. knope/vX.Y.Z), so the generic \"simple mise tools\" manager above can't be used: extractVersionTemplate is what filters the mixed-prefix tags down to just knope's own",
+      "description": "Manager for the knope mise tool pin: knope-dev/knope is a monorepo that tags each crate's releases separately (e.g. knope/vX.Y.Z), so the generic \"simple mise tools\" manager above can't be used: extractVersionTemplate is what filters the mixed-prefix tags down to just knope's own",
       "customType": "regex",
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "knope-dev/knope",
@@ -304,7 +304,7 @@
       "versioningTemplate": "pep440"
     }{% if is_template %},
     {
-      "description": "Manager for npm-backed mise tools with options -- mirrors \"Manager for pipx tools with options\" above, but for the npm: backend prefix (datasource npm instead of pypi). A separate manager because that one's datasource is hardcoded to pypi.",
+      "description": "Manager for npm-backed mise tools with options: mirrors \"Manager for pipx tools with options\" above, but for the npm: backend prefix (datasource npm instead of pypi). A separate manager because that one's datasource is hardcoded to pypi.",
       "customType": "regex",
       "datasourceTemplate": "npm",
       "managerFilePatterns": [

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -40,7 +40,7 @@ parent_template_url:
 ## Start Migrations
 _migrations:
   # release-please wrote CHANGELOG.md headings as `## [X.Y.Z](url) (date)`, which
-  # Knope's changelog writer can't parse -- it silently appends new releases at the
+  # Knope's changelog writer can't parse; it silently appends new releases at the
   # end of the file instead of the top once it can't find a heading it recognizes. A
   # project that adopted this template before the Knope switch has that same stale
   # formatting, so it needs the same one-time reformat this repo's own CHANGELOG.md
@@ -71,13 +71,13 @@ _migrations:
     version: v0.8.1
     when: "{{ _stage == 'after' }}"
 
-  # No `version:` -- this runs on every update, not just once, so upstream changes
-  # actually show up in this project's own changelog instead of vanishing into an
+  # This runs on every update, not on one version transition, so upstream changes
+  # show in this project's own changelog instead of vanishing into an
   # opaque "chore: apply parent template" commit. Computes the real bump/changelog
   # content by running Knope's own compute-upstream-bump workflow for real (not
   # --dry-run) inside a throwaway clone of the template, with every tag but this
   # project's old template version hidden so Knope's own "most recent tag" baseline
-  # lands on the actual delta -- see that workflow's comment in knope.toml for why.
+  # lands on the actual delta; see that workflow's comment in knope.toml for why.
   # Silently does nothing if there's no qualifying commit to bump (e.g. an
   # internal-only template change) or if the old version isn't a real tag in the
   # template's history.
@@ -252,7 +252,7 @@ developer_platform:
   help: |
     {%- if not project_initialized -%}
       The platform where you are going to host your Git repo and CI/CD. Azure DevOps
-      support is deprecated and will eventually be removed -- prefer GitHub unless you
+      support is deprecated and will eventually be removed; prefer GitHub unless you
       specifically need Azure DevOps.
     {%- else -%}
       Locked value on update, press Enter.
@@ -289,7 +289,7 @@ repo_setup_actions:
           {%- elif repo_setup_actions == 'Create Repo' -%}
             {%- set knope_check = ('knope --version && echo KNOPE_INSTALLED' | shell()) -%}
             {%- if 'KNOPE_INSTALLED' not in knope_check -%}
-              Knope ('knope') is not installed or not on PATH -- it's used to stage this project's first release. Install it (see https://knope.tech/), then try again.
+              Knope ('knope') is not installed or not on PATH. Install it (see https://knope.tech/), then try again.
             {%- endif -%}
           {%- endif -%}
         {%- endif -%}
@@ -308,7 +308,7 @@ repo_setup_actions:
             {%- elif repo_setup_actions == 'Create Repo' -%}
               {%- set knope_check = ('knope --version && echo KNOPE_INSTALLED' | shell()) -%}
               {%- if 'KNOPE_INSTALLED' not in knope_check -%}
-                Knope ('knope') is not installed or not on PATH -- it's used to stage this project's first release. Install it (see https://knope.tech/), then try again.
+                Knope ('knope') is not installed or not on PATH. Install it (see https://knope.tech/), then try again.
               {%- endif -%}
             {%- endif -%}
           {%- endif -%}
@@ -469,7 +469,7 @@ lifecycle:
   validator: |-
     {%- set _rank = {"Pre-Alpha": 0, "Alpha": 1, "Beta": 2, "Stable": 3} -%}
     {%- if lifecycle_previous in _rank and lifecycle in _rank and _rank[lifecycle] < _rank[lifecycle_previous] -%}
-      Can't move from '{{ lifecycle_previous }}' back to '{{ lifecycle }}' -- lifecycle only moves forward (Pre-Alpha -> Alpha -> Beta -> Stable). 'Inactive' is a separate state, reachable from any of these.
+      Can't move from '{{ lifecycle_previous }}' back to '{{ lifecycle }}': lifecycle only moves forward (Pre-Alpha -> Alpha -> Beta -> Stable). 'Inactive' is a separate state, reachable from any of these.
     {%- endif -%}
 
 agent_instructions:
@@ -479,7 +479,7 @@ agent_instructions:
 
 code_coverage:
   type: bool
-  help: Report code coverage via Codecov (GitHub) or Azure Pipelines' built-in publishing (Azure DevOps) -- wires up reporting only, your test command needs to produce coverage.xml (Cobertura) at the repo root.
+  help: Report code coverage via Codecov (GitHub) or Azure Pipelines' built-in publishing (Azure DevOps). This wires up reporting only, your test command needs to produce coverage.xml (Cobertura) at the repo root.
   default: false
 ## End Questions
 
@@ -615,10 +615,10 @@ current_knope_version_is_pre_1:
 setup_checklist:
   type: str
   default: |-
-    - [ ] Add more badges to the top of README.md, or remove that section.
+    - [ ] Add/remove badges to the top of README.md.
     - [ ] Replace docs/images/readme-logo.png with your own logo, or remove that section from README.md.
     - [ ] Replace docs/images/readme-screenshot.png with a real screenshot of your project, or remove that section from README.md.
-    - [ ] Set required secrets/pipeline variables -- run `mise run provision-secrets` or see docs/token-permissions.md.
+    - [ ] Set required secrets/pipeline variables: run `mise run provision-secrets` or see docs/token-permissions.md.
   when: false
 ## End Post-Question Computed Values
 
@@ -785,7 +785,7 @@ _tasks:
     when: *when_copy_set_repo_settings_azdo
 
   # A freshly-registered AzDO YAML pipeline's push-based CI trigger doesn't reliably
-  # activate until the pipeline has run at least once -- confirmed via live testing (a
+  # activate until the pipeline has run at least once; confirmed via live testing (a
   # real push produced zero pipeline runs until a manual run was queued first). This
   # one-time warm-up run activates it for every push after.
   - command: >-
@@ -811,7 +811,7 @@ _tasks:
   # Requires the pr_validation build to pass before a PR can be completed, and lets
   # Project Administrators override that when completing a PR (mirrors GitHub's
   # admin bypass_actors entry in settings.yml.jinja). `az repos policy` has no flag
-  # for the override part -- it's a branch-level security permission instead, set
+  # for the override part; it's a branch-level security permission instead, set
   # via the raw security-namespace API since `az repos`/`az devops` has no
   # higher-level command for it. Namespace ID, permission bit, and token format
   # aren't in Microsoft's own CLI docs; cross-checked against
@@ -825,7 +825,7 @@ _tasks:
 
         ORG = "https://dev.azure.com/{{ azdo_org }}/"
         PROJECT = "{{ azdo_project }}"
-        # az is an az.cmd batch wrapper on Windows, not a real .exe -- subprocess with
+        # az is an az.cmd batch wrapper on Windows, not a real .exe; subprocess with
         # shell=False (the default, used throughout below) won't find it from the bare
         # name alone, failing with FileNotFoundError: [WinError 2]. which() finds the
         # actual resolvable path on any platform, sidestepping that gap without
@@ -873,7 +873,7 @@ _tasks:
             for g in groups["graphGroups"]
             if g["displayName"] == "Project Administrators"
         )
-        # refs/heads/main, UTF-16LE hex-encoded per character -- Azure DevOps's Git
+        # refs/heads/main, UTF-16LE hex-encoded per character; Azure DevOps's Git
         # ACL token format for a specific branch.
         token = f"repoV2/{project_id}/{repo_id}/refs/heads/6d00610069006e00"
         subprocess.run(
@@ -930,7 +930,7 @@ _tasks:
         true
       {%- endif %}
 
-  # Enables CodeQL code scanning's default setup -- free for public repos, needs
+  # Enables CodeQL code scanning's default setup; free for public repos, needs
   # GitHub Advanced Security (paid) on private ones, so scoped to public only.
   - command: >-
       gh api repos/{{ github_repo_owner }}/{{ repo_name }}/code-scanning/default-setup
@@ -941,7 +941,7 @@ _tasks:
       {%- endif %}
 
   # Lets anyone privately report a security vulnerability (Security > Advisories)
-  # instead of only via a public issue -- meaningful for public repos specifically,
+  # instead of only via a public issue; meaningful for public repos specifically,
   # since a private repo's issues are already restricted to invited collaborators.
   - command: gh api repos/{{ github_repo_owner }}/{{ repo_name }}/private-vulnerability-reporting -X PUT
     when: *when_copy_public_github
@@ -985,11 +985,11 @@ _message_after_copy: |-
   {%- if code_coverage %}
     - CODECOV_TOKEN
   {%- endif %}
-  Run `mise run provision-secrets` for a guided, masked prompt, or set them by hand -- see docs/token-permissions.md for what each one needs.
+  Run `mise run provision-secrets`, or see docs/token-permissions.md for manual provisioning details.
   {%- elif using_azdo -%}
   Before CI works, add these as secret Azure DevOps pipeline variables (Pipelines > Library):
     - APPRISE_URL
-  Run `mise run provision-secrets` for a guided, masked prompt, or set them by hand -- see docs/token-permissions.md for what each one needs.
+  Run `mise run provision-secrets`, or see docs/token-permissions.md for manual provisioning details.
   {%- endif %}
 
 _message_after_update: |-

--- a/template/{% if is_template %}docs{% endif %}/index.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/index.md.jinja
@@ -52,7 +52,7 @@ It is highly encouraged for you to take this template and make your own child te
 - Setting of repo settings & branch protection rules
 - Creation of useful non-default issue labels: `awaiting pr` and `blocked`
 - Contributor management and crediting via [All Contributors](https://allcontributors.org/)
-- Dependency updates via [Renovate](https://www.mend.io/renovate/) -- the [GitHub Marketplace
+- Dependency updates via [Renovate](https://www.mend.io/renovate/); the [GitHub Marketplace
   App](https://github.com/marketplace/renovate/) on GitHub, a self-hosted scheduled pipeline on
   Azure DevOps
 - Scheduled checks for updates from parent template
@@ -80,7 +80,7 @@ Rich Markdown documentation is pre-configured using [Zensical](https://zensical.
 ### CI/CD
 
 - Version number calculation, changelog updating, releasing, and tagging via
-  [Knope](https://knope.tech/) -- see [Releasing](releasing.md)
+  [Knope](https://knope.tech/); see [Releasing](releasing.md)
 - Simple/example release pipeline via GitHub Actions or Azure Pipelines
 
 ### Support Files

--- a/template/{% if is_template %}docs{% endif %}/integration-testing.md
+++ b/template/{% if is_template %}docs{% endif %}/integration-testing.md
@@ -1,36 +1,36 @@
 # Integration Testing
 
-**Run this as the last step before cutting every release.** It's the only way to catch a real regression in this template's own scaffolding -- a local render can't create a repo, register a pipeline, or trigger a workflow, and those are exactly the things a release needs to still work.
+**Run this as the last step before cutting every release.** It's the only way to catch a real regression in this template's own scaffolding; a local render can't create a repo, register a pipeline, or trigger a workflow, and those are exactly the things a release needs to still work.
 
 Integration testing means actually running the template: creating a real throwaway repo from the current template source and confirming the result holds up, not just inspecting a local render.
 
 ## Running It
 
-- `mise run integration-test-gh` -- creates two real GitHub repos from this template, named `<prefix>-integration-test-<timestamp>-a` and `...-b`.
-- `mise run integration-test-azdo` -- the same shape, on Azure DevOps (pass `--org`/`--project`, or let them default to this project's own if it already uses Azure DevOps).
+- `mise run integration-test-gh`: creates two real GitHub repos from this template, named `<prefix>-integration-test-<timestamp>-a` and `...-b`.
+- `mise run integration-test-azdo`: the same shape, on Azure DevOps (pass `--org`/`--project`, or let them default to this project's own if it already uses Azure DevOps).
 
-Run both, regardless of which platform this template's own repo happens to use -- a release has to be good for every platform this template supports, not just the one you personally host on.
+Run both, regardless of which platform this template's own repo happens to use; a release has to be good for every platform this template supports, not just the one you personally host on.
 
 ## Repo A and Repo B
 
 Each run creates two repos with deliberately different answers, so between them a single run covers more of the answer space instead of exercising the same fixed answers twice. Each checklist below has a matching section per repo.
 
-- **Repo A** is a plain `copier copy` at `HEAD`, ready to check immediately -- both `mise run integration-test-gh`/`integration-test-azdo` run every automated check they can against it directly (dispatching pipelines, opening real PRs, cutting a real release) before returning.
-- **Repo B** is copied at the last stable release tag and left there -- it does *not* get updated for you. Applying that update is deliberately a manual step, spelled out in each checklist's own Repo B section: running the exact command a real user runs, prompts included, is the only way to see a new question land the way it actually would for them, not however a script might have answered it. Once you've updated it by hand, `mise run integration-test-verify-update-gh`/`integration-test-verify-update-azdo` automates checking that it applied cleanly.
+- **Repo A** is a plain `copier copy` at `HEAD`, ready to check immediately; both `mise run integration-test-gh`/`integration-test-azdo` run every automated check they can against it directly (dispatching pipelines, opening real PRs, cutting a real release) before returning.
+- **Repo B** is copied at the last stable release tag and left there; it does *not* get updated for you. Applying that update is deliberately a manual step, spelled out in each checklist's own Repo B section: running the exact command a real user runs, prompts included, is the only way to see a new question land the way it actually would for them, not however a script might have answered it. Once you've updated it by hand, `mise run integration-test-verify-update-gh`/`integration-test-verify-update-azdo` automates checking that it applied cleanly.
 
 The two repos also split every other either/or answer this template offers, so both branches get exercised somewhere: `code_coverage` is on for Repo A and off for Repo B on both platforms; on GitHub, `zensical_target` is `GitHub Pages` for Repo A and `docs-site Directory in Repo` for Repo B.
 
 ## What It Checks, and What It Doesn't
 
-Both scripts check as much as is feasible for them to automatically: they dispatch real pipelines and wait for them to finish, open real PRs and confirm they're blocked or pass, push real commits and confirm the release flow reacts correctly, and cut a real release and prerelease. Every check prints its own `[PASS]`/`[FAIL]` line as it runs, plus a summary at the end -- nothing stops at the first failure, so one run gives the full picture.
+Both scripts check as much as is feasible for them to automatically: they dispatch real pipelines and wait for them to finish, open real PRs and confirm they're blocked or pass, push real commits and confirm the release flow reacts correctly, and cut a real release and prerelease. Every check prints its own `[PASS]`/`[FAIL]` line as it runs, plus a summary at the end; nothing stops at the first failure, so one run gives the full picture.
 
-What's still out of reach: anything that depends on a human's judgment (does a badge actually look right, was the setup checklist genuinely addressed) or an external system this script can't inspect (whether an Apprise notification actually landed at your configured endpoint, whether a third-party bot like Renovate or All Contributors responded). That's what the checklists are for -- each one only lists what's actually left for a human, with a note wherever a check nearby is already automated.
+What's still out of reach: anything that depends on a human's judgment (does a badge actually look right, was the setup checklist genuinely addressed) or an external system this script can't inspect (whether an Apprise notification actually landed at your configured endpoint, whether a third-party bot like Renovate or All Contributors responded). That's what the checklists are for; each one only lists what's actually left for a human, with a note wherever a check nearby is already automated.
 
 ## vs. `pytest tests/`
 
-`pytest tests/` (`mise run test`; CI runs the same command directly on every PR) already covers a lot of this template's own correctness, including an update-path check (`test_update_from_last_tag`) that runs a real `copier update` against a real git history -- but entirely locally: it renders into a temp directory, never touches GitHub or Azure DevOps, and skips every `_tasks` entry (`--skip-tasks`), so it can't create a repo, register a pipeline, or apply a branch policy for real. It's what catches broken Jinja, invalid YAML/JSON, dead links, and template-diff bugs, fast and on every PR, with no external side effects.
+`pytest tests/` (`mise run test`; CI runs the same command directly on every PR) already covers a lot of this template's own correctness, including an update-path check (`test_update_from_last_tag`) that runs a real `copier update` against a real git history, but entirely locally: it renders into a temp directory, never touches GitHub or Azure DevOps, and skips every `_tasks` entry (`--skip-tasks`), so it can't create a repo, register a pipeline, or apply a branch policy for real. It's what catches broken Jinja, invalid YAML/JSON, dead links, and template-diff bugs, fast and on every PR, with no external side effects.
 
-Integration testing picks up exactly where that stops: anything gated on a real API call, a real running pipeline, or an external system's own behavior -- none of which a local render can exercise, which is why this has to be a manual, pre-release step rather than something CI runs on every PR.
+Integration testing picks up exactly where that stops: anything gated on a real API call, a real running pipeline, or an external system's own behavior; none of which a local render can exercise, which is why this has to be a manual, pre-release step rather than something CI runs on every PR.
 
 Run through **all of** the relevant checklist, by hand, against the repos the integration test just created:
 

--- a/template/{% if is_template %}docs{% endif %}/javascripts/manual-verification-checkboxes.js
+++ b/template/{% if is_template %}docs{% endif %}/javascripts/manual-verification-checkboxes.js
@@ -1,9 +1,9 @@
 // Scoped to this one page rather than a site-wide pymdownx.tasklist clickable_checkbox
-// config change, which would make every task list on the docs site clickable -- most
+// config change, which would make every task list on the docs site clickable; most
 // docs don't have one, and the ones that do shouldn't opt in silently. This only
 // removes the disabled attribute pymdownx.tasklist renders by default (the same DOM
 // change clickable_checkbox itself makes), so checkboxes are toggleable purely as a
-// visual scratchpad -- see the doc's own warning about state not being saved.
+// visual scratchpad; see the doc's own warning about state not being saved.
 if (location.pathname.includes("manual-verification")) {
   document.querySelectorAll(".task-list-item input[type=checkbox]").forEach((checkbox) => {
     checkbox.disabled = false;

--- a/template/{% if is_template %}docs{% endif %}/manual-repo-settings.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/manual-repo-settings.md.jinja
@@ -6,7 +6,7 @@ When you use the [Settings GitHub App](https://github.com/apps/settings), it syn
 settings, labels, and branch protection ruleset described below from the committed
 `.github/settings.yml` automatically. If you don't want to install that app (or can't, e.g. it's
 not been approved for your organization), here's how to apply the same configuration by hand
-through the GitHub UI. `.github/settings.yml` is the source of truth for the exact values below --
+through the GitHub UI. `.github/settings.yml` is the source of truth for the exact values below;
 if the two ever disagree, trust the file.
 
 ### Labels
@@ -44,7 +44,7 @@ Under **Settings > Rules > Rulesets**, create a new ruleset:
     - **Require status checks to pass**, with:
         - Require branches to be up to date before merging: on
         - Status check: `tests` (the job in `Test (Auto): PR Validation`)
-- Bypass list: add **Repository admin**, with bypass mode **Pull requests only** -- this lets
+- Bypass list: add **Repository admin**, with bypass mode **Pull requests only**; this lets
   repo admins use the "Merge without waiting for requirements to be met" button instead of being
   blocked entirely.
 
@@ -58,7 +58,7 @@ After the first successful Pages deployment, an environment named `github-pages`
 
 ### Security and Analysis
 
-(Public repos only -- private repos need a paid GitHub Advanced Security license.)
+(Public repos only; private repos need a paid GitHub Advanced Security license.)
 
 Under **Settings > Code security**, enable **Secret scanning** and **Push protection**.
 
@@ -89,5 +89,5 @@ a **Build Validation** policy:
 ### Bypass Permission
 
 Under **Project Settings > Repositories > (this repo) > Security**, select **Project
-Administrators** and set **Bypass policies when completing pull requests** to **Allow** -- this
+Administrators** and set **Bypass policies when completing pull requests** to **Allow**; this
 lets project admins use the "Complete" button's bypass option instead of being blocked entirely.

--- a/template/{% if is_template %}docs{% endif %}/manual-verification-azdo.md
+++ b/template/{% if is_template %}docs{% endif %}/manual-verification-azdo.md
@@ -1,10 +1,10 @@
 # Manual Verification Checklist (Azure DevOps)
 
-Run through this **in full**, by hand, as the last step before cutting a release. See [Integration Testing](integration-testing.md) for what `mise run integration-test-azdo` creates and why the update step below isn't automated. Most of Repo A's checks are now automated -- each `mise run integration-test-*-azdo` invocation prints its own PASS/FAIL per check, plus a summary; what's below is what's left for a human.
+Run through this **in full**, by hand, as the last step before cutting a release. See [Integration Testing](integration-testing.md) for what `mise run integration-test-azdo` creates and why the update step below isn't automated. Most of Repo A's checks are now automated; each `mise run integration-test-*-azdo` invocation prints its own PASS/FAIL per check, plus a summary; what's below is what's left for a human.
 
 !!! bug "Checkbox state isn't saved"
     Boxes on this page are clickable so you can tick items off as you go, but nothing
-    persists that -- reloading or leaving the page resets every box to unchecked. Treat
+    persists that; reloading or leaving the page resets every box to unchecked. Treat
     it as a scratchpad for one sitting, not a record you can come back to.
 
 ## Repo A
@@ -13,18 +13,18 @@ Fresh copy at `HEAD`, `code_coverage` on.
 
 ### After First Setup
 
-*Branch protection actually blocking a bad PR is automated -- see "a bad-title PR fails Test (Auto) - PR Validation" and its blocked-merge counterpart in the script's own output.*
+*Branch protection actually blocking a bad PR is automated; see "a bad-title PR fails Test (Auto) - PR Validation" and its blocked-merge counterpart in the script's own output.*
 
 - [ ] The setup checklist (printed to the console at the end of `copier copy`) exists and every item on it has been addressed.
 - [ ] Badges at the top of README.md render correctly (no broken image icons).
 - [ ] `docs/images/readme-logo.png` and `docs/images/readme-screenshot.png` display correctly in README.md, or that section has been removed if unused.
-- [ ] Required secrets/pipeline variables are provisioned (`mise run provision-secrets`, or see [Token Permissions](token-permissions.md)) -- confirmed by the pipelines below not failing with authentication errors.
+- [ ] Required secrets/pipeline variables are provisioned (`mise run provision-secrets`, or see [Token Permissions](token-permissions.md)); confirmed by the pipelines below not failing with authentication errors.
 
 ### Maint (Auto) - Copier Update Check
 
-*Dispatching it and confirming it completes without error are automated. Whether it correctly reports no update available isn't -- `az` has no cheap way to read a pipeline run's own step output, see the script's own module docstring for why.*
+*Dispatching it and confirming it completes without error are automated. Whether it correctly reports no update available isn't; `az` has no cheap way to read a pipeline run's own step output, see the script's own module docstring for why.*
 
-- [ ] Confirm it correctly reports **no update available** -- this repo is already at `HEAD`.
+- [ ] Confirm it correctly reports **no update available**; this repo is already at `HEAD`.
 
 ### Maint (Auto) - Repo Health Check
 
@@ -37,7 +37,7 @@ Fresh copy at `HEAD`, `code_coverage` on.
 *Dispatching it and confirming it authenticates successfully are automated.*
 
 - [ ] With at least one outdated dependency present, confirm it opens (or updates) a real pull request proposing the bump.
-- [ ] Confirm the one-time **Project Collection Build Service** permission grant described in [Azure DevOps Limitations](platform-notes/azure-devops.md) is actually in place -- a missing grant surfaces as a push/PR-creation failure here, not a clear permissions error.
+- [ ] Confirm the one-time **Project Collection Build Service** permission grant described in [Azure DevOps Limitations](platform-notes/azure-devops.md) is actually in place; a missing grant surfaces as a push/PR-creation failure here, not a clear permissions error.
 
 ### Docs (Auto) - Zensical Build & Publish
 
@@ -47,14 +47,14 @@ Fresh copy at `HEAD`, `code_coverage` on.
 
 *A bad-title PR failing, and a PR with a failing test suite failing and being blocked from merging, are both automated.*
 
-- [ ] Confirm `coverage.xml` publishes successfully and shows up on the build -- `code_coverage` is on for this repo.
-- [ ] Azure Repos has no native PR-triggered pipeline run -- this pipeline is triggered solely by the build-validation branch policy. Confirm pushing a new commit to an open PR actually kicks off a fresh run (not just the PR's initial creation).
+- [ ] Confirm `coverage.xml` publishes successfully and shows up on the build; `code_coverage` is on for this repo.
+- [ ] Azure Repos has no native PR-triggered pipeline run; this pipeline is triggered solely by the build-validation branch policy. Confirm pushing a new commit to an open PR actually kicks off a fresh run (not just the PR's initial creation).
 
 ### Release (Auto) - Prepare & Publish Release
 
 *The full flow is automated: a docs-only commit staying a no-op, a feat commit opening a release PR with a version-bump title, and merging that PR publishing a tag.*
 
-- [ ] Confirm the pipeline correctly tells "a normal push to `main`" apart from "this push is the release PR's own merge" -- it does this via an API check, not a native trigger, so push a second, unrelated commit right after a release and confirm it doesn't also try to publish.
+- [ ] Confirm the pipeline correctly tells "a normal push to `main`" apart from "this push is the release PR's own merge"; it does this via an API check, not a native trigger, so push a second, unrelated commit right after a release and confirm it doesn't also try to publish.
 
 ### Release (Manual) - Create Prerelease
 
@@ -64,7 +64,7 @@ Nothing left here for Repo A.
 
 ## Repo B
 
-Copied at the last stable release tag, `code_coverage` off. Still at that tag -- nothing here has been updated for you.
+Copied at the last stable release tag, `code_coverage` off. Still at that tag; nothing here has been updated for you.
 
 ### Before Updating
 
@@ -84,5 +84,5 @@ Run `mise run integration-test-verify-update-azdo -- --repo <repo> --local-path 
 
 ## Cleaning Up
 
-- [ ] Run `python cleanup_pipelines.py` in each throwaway repo's local directory (left there by the integration test, next to the repo's own files) before deleting the repos -- Azure DevOps has no bulk-delete UI for pipelines, so skipping this means removing each one by hand through its own settings page.
+- [ ] Run `python cleanup_pipelines.py` in each throwaway repo's local directory (left there by the integration test, next to the repo's own files) before deleting the repos; Azure DevOps has no bulk-delete UI for pipelines, so skipping this means removing each one by hand through its own settings page.
 - [ ] Delete both repos (Project Settings > Repositories, or `az repos delete`).

--- a/template/{% if is_template %}docs{% endif %}/manual-verification-github.md
+++ b/template/{% if is_template %}docs{% endif %}/manual-verification-github.md
@@ -1,10 +1,10 @@
 # Manual Verification Checklist (GitHub)
 
-Run through this **in full**, by hand, as the last step before cutting a release. See [Integration Testing](integration-testing.md) for what `mise run integration-test-gh` creates and why the update step below isn't automated. Most of Repo A's checks are now automated -- each `mise run integration-test-*-gh` invocation prints its own PASS/FAIL per check, plus a summary; what's below is what's left for a human.
+Run through this **in full**, by hand, as the last step before cutting a release. See [Integration Testing](integration-testing.md) for what `mise run integration-test-gh` creates and why the update step below isn't automated. Most of Repo A's checks are now automated; each `mise run integration-test-*-gh` invocation prints its own PASS/FAIL per check, plus a summary; what's below is what's left for a human.
 
 !!! bug "Checkbox state isn't saved"
     Boxes on this page are clickable so you can tick items off as you go, but nothing
-    persists that -- reloading or leaving the page resets every box to unchecked. Treat
+    persists that; reloading or leaving the page resets every box to unchecked. Treat
     it as a scratchpad for one sitting, not a record you can come back to.
 
 ## Repo A
@@ -13,12 +13,12 @@ Fresh copy at `HEAD`, `zensical_target: GitHub Pages`, `code_coverage` on.
 
 ### After First Setup
 
-*Branch protection actually blocking a bad PR is automated -- see "a bad-title PR fails Test (Auto): PR Validation" and "branch protection blocks merging a PR with a bad PR title" in the script's own output.*
+*Branch protection actually blocking a bad PR is automated; see "a bad-title PR fails Test (Auto): PR Validation" and "branch protection blocks merging a PR with a bad PR title" in the script's own output.*
 
 - [ ] The setup checklist (a GitHub Issue titled "Post-Setup Checklist," opened automatically on first copy) exists and every item on it has been addressed.
 - [ ] Badges at the top of README.md render correctly (no broken image icons).
 - [ ] `docs/images/readme-logo.png` and `docs/images/readme-screenshot.png` display correctly in README.md, or that section has been removed if unused.
-- [ ] Required secrets/pipeline variables are provisioned (`mise run provision-secrets`, or see [Token Permissions](token-permissions.md)) -- confirmed by the pipelines below not failing with authentication errors.
+- [ ] Required secrets/pipeline variables are provisioned (`mise run provision-secrets`, or see [Token Permissions](token-permissions.md)); confirmed by the pipelines below not failing with authentication errors.
 
 ### Maint (Auto): Copier Update Check
 
@@ -35,7 +35,7 @@ Nothing left here for Repo A.
 
 ### Maint (Auto): Renovate
 
-Renovate on GitHub runs as the externally-hosted [Renovate GitHub App](https://github.com/apps/renovate), not a workflow in this repo -- there's nothing to dispatch or verify from inside this repo's own CI.
+Renovate on GitHub runs as the externally-hosted [Renovate GitHub App](https://github.com/apps/renovate), not a workflow in this repo; there's nothing to dispatch or verify from inside this repo's own CI.
 
 - [ ] Confirm the app is installed with access to this repo (Settings > Integrations, or your account/org's installed GitHub Apps).
 - [ ] Wait for its own schedule (or check its dashboard for how to trigger an out-of-schedule run) and confirm it authenticates successfully.
@@ -43,7 +43,7 @@ Renovate on GitHub runs as the externally-hosted [Renovate GitHub App](https://g
 
 ### Maint (Auto): All Contributors
 
-(Public repos only -- both repos are Public, so either would do; this repo is as good a place as any.)
+(Public repos only; both repos are Public, so either would do; this repo is as good a place as any.)
 
 - [ ] Comment `@all-contributors please add @<username> for <contribution>` on an issue or PR, and confirm the bot opens a PR adding that person to the Contributors section of README.md.
 
@@ -56,7 +56,7 @@ Renovate on GitHub runs as the externally-hosted [Renovate GitHub App](https://g
 
 *A bad-title PR failing, and a PR with a failing test suite failing and being blocked from merging, are both automated.*
 
-- [ ] Confirm `coverage.xml` uploads to Codecov successfully and the report/badge reflects it -- `code_coverage` is on for this repo.
+- [ ] Confirm `coverage.xml` uploads to Codecov successfully and the report/badge reflects it; `code_coverage` is on for this repo.
 
 ### Release (Auto): Prepare/Publish Release
 
@@ -72,7 +72,7 @@ Nothing left here for Repo A.
 
 ## Repo B
 
-Copied at the last stable release tag, `zensical_target: docs-site Directory in Repo`, `code_coverage` off. Still at that tag -- nothing here has been updated for you.
+Copied at the last stable release tag, `zensical_target: docs-site Directory in Repo`, `code_coverage` off. Still at that tag; nothing here has been updated for you.
 
 ### Before Updating
 
@@ -91,4 +91,4 @@ Run `mise run integration-test-verify-update-gh -- --repo <repo> --local-path <p
 
 ## Cleaning Up
 
-- [ ] Delete both throwaway repos (`gh repo delete <repo> --yes`, or via the web UI) -- deleting a GitHub repo removes everything registered against it, workflows included.
+- [ ] Delete both throwaway repos (`gh repo delete <repo> --yes`, or via the web UI); deleting a GitHub repo removes everything registered against it, workflows included.

--- a/template/{% if is_template %}docs{% endif %}/platform-notes/azure-devops.md
+++ b/template/{% if is_template %}docs{% endif %}/platform-notes/azure-devops.md
@@ -1,7 +1,7 @@
 # Azure DevOps Limitations
 
 **Azure DevOps support is deprecated and will eventually be removed.** It's kept around for
-existing organizational needs, not as a recommendation -- prefer GitHub for new projects unless
+existing organizational needs, not as a recommendation; prefer GitHub for new projects unless
 you specifically need Azure DevOps.
 
 Support for Azure DevOps is provided on a best-effort basis and has some limitations compared to GitHub.
@@ -15,7 +15,7 @@ Support for Azure DevOps is provided on a best-effort basis and has some limitat
       automatically on the default branch (the `Test (Auto) - PR Validation` pipeline must pass
       before a PR can complete), along with a **Project Administrators** bypass permission mirroring GitHub's
       admin `bypass_actors` entry. Unlike GitHub's ruleset, force-push and branch deletion on the
-      default branch are **not** blocked -- this is a known, currently-accepted gap. If you chose
+      default branch are **not** blocked; this is a known, currently-accepted gap. If you chose
       `repo_setup_actions: None`, see [Manual Repo Settings](../manual-repo-settings.md) for how to
       set this up by hand.
 - `zensical_target` is always `docs-site Directory in Repo`
@@ -27,11 +27,11 @@ Support for Azure DevOps is provided on a best-effort basis and has some limitat
       `$(System.AccessToken)` rather than a stored secret. For it to push branches and open PRs,
       grant the **Project Collection Build Service** account **Contribute**, **Create branch**,
       and **Contribute to pull requests** on this repo (Project Settings > Repositories > this
-      repo > Security) -- this is normally a one-time, org-wide grant, not something you need to
+      repo > Security); this is normally a one-time, org-wide grant, not something you need to
       repeat per repo.
 - `Release (Auto) - Prepare & Publish Release` pipeline detects PR merges via the API, not a native trigger
     - The release flow matches GitHub's: every push to `main` opens or updates a preview PR
-      (`knope/release`), and merging it publishes the release -- see [Releasing](../releasing.md).
+      (`knope/release`), and merging it publishes the release; see [Releasing](../releasing.md).
       Azure Pipelines has no "PR completed" trigger, only branch-push triggers, so the pipeline
       tells "a normal push" apart from "this push is that PR's own merge" by asking the API
       whether the most recently completed PR from `knope/release` into `main` matches the commit

--- a/template/{% if is_template %}docs{% endif %}/prerequisites.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/prerequisites.md.jinja
@@ -5,16 +5,16 @@
 ### One-Time Actions Per Azure DevOps Organization
 
 1. Install the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) (`az`) via an
-    officially supported method (winget/MSI on Windows, Homebrew on macOS, apt/dnf/zypper on Linux
-    -- installing via pip/pipx is not supported by Microsoft), then run
+    officially supported method (winget/MSI on Windows, Homebrew on macOS, apt/dnf/zypper on Linux,
+    since installing via pip/pipx is not supported by Microsoft), then run
     `az extension add --name azure-devops` and `az login`. Unless you choose `None` for the
     `repo_setup_actions` question, this is used instead of a Personal Access Token to create your
     repo and register its pipelines. The `repo_setup_actions` question's validator checks that
     `az`, the `azure-devops` extension, and login are all in place before letting you proceed.
 1. Make sure [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager) is
     installed (bundled with Git for Windows if you enabled it during install; a separate install on
-    macOS/Linux). The initial `git push` isn't covered by `az login` -- see
-    [Token Permissions](token-permissions.md#az-login-permissions) for why -- so GCM handles that
+    macOS/Linux). The initial `git push` isn't covered by `az login` (see
+    [Token Permissions](token-permissions.md#az-login-permissions) for why), so GCM handles that
     push's authentication with its own (separate) interactive Entra sign-in the first time.
 
 ### One-Time Actions per Azure DevOps Project
@@ -44,8 +44,8 @@ In order to support the proper parsing of Conventional Commits, the following mu
     proceed.
 1. Make sure [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager) is
     installed (bundled with Git for Windows if you enabled it during install; a separate install on
-    macOS/Linux). `gh auth login`'s default scopes don't cover pushing `.github/workflows/` files --
-    see [Token Permissions](token-permissions.md#gh-auth-login-scopes) for why -- so GCM handles the
+    macOS/Linux). `gh auth login`'s default scopes don't cover pushing `.github/workflows/` files
+    (see [Token Permissions](token-permissions.md#gh-auth-login-scopes) for why), so GCM handles the
     initial push with its own (separate) interactive GitHub sign-in the first time.
 1. Install the [AllContributors GitHub App](https://github.com/apps/allcontributors/installations/new) for your user or organization.
     - This app provides automatic README crediting when other people contribute to your project
@@ -57,15 +57,15 @@ In order to support the proper parsing of Conventional Commits, the following mu
 1. Install the [Settings GitHub App](https://github.com/apps/settings) for your user or organization.
     - This app syncs repo settings (labels, merge options, branch protection) from the committed `.github/settings.yml`, which is always generated for GitHub projects
     - It must have access to a repo *before* that repo is created for its settings to apply, so grant it access to all your repositories up front, same as the apps above
-    - Skipping this is fine -- see [Manual Repo Settings](manual-repo-settings.md) for how to apply the same configuration by hand instead
+    - Skipping this is fine; see [Manual Repo Settings](manual-repo-settings.md) for how to apply the same configuration by hand instead
 1. Install the [Codecov GitHub App](https://github.com/apps/codecov) for your user or organization.
     - This app powers Codecov's PR comments/checks and connects your repo to codecov.io for uploads
-    - Only needed if you plan to answer Yes to the `code_coverage` question -- skip this if you don't want code coverage reporting
+    - Only needed if you plan to answer Yes to the `code_coverage` question; skip this if you don't want code coverage reporting
     - It is recommended that you give it access to all your repositories, which means you only need to do this step once rather than for each new repo.
 
 ## Personal Access Tokens
 
-Neither platform needs one for repo setup anymore -- see the `az login`/`gh auth login` steps
+Neither platform needs one for repo setup anymore; see the `az login`/`gh auth login` steps
 above. See [Token Permissions](token-permissions.md) for the permissions the signed-in account
 needs instead on Azure DevOps, and for the separate, ongoing **Repo Maintenance PAT** used by
 this project's own GitHub Actions workflows.

--- a/template/{% if is_template %}docs{% endif %}/template-questions.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/template-questions.md.jinja
@@ -20,9 +20,9 @@ entirely. Prefer GitHub for new projects unless you specifically need Azure DevO
 ## `repo_setup_actions`: Create Repo / Set Repo Rules / None
 
 Controls which setup automation runs after the template is copied. `.github/settings.yml` (GitHub
-only) is always generated regardless of this answer -- see below. Choosing anything but `None`
+only) is always generated regardless of this answer; see below. Choosing anything but `None`
 triggers this question's validator, which checks the relevant platform CLI (`gh` or `az`) is
-installed and authenticated *before* letting you proceed -- see [Prerequisites](prerequisites.md).
+installed and authenticated *before* letting you proceed; see [Prerequisites](prerequisites.md).
 
 - **Create Repo** — creates the remote repo; on GitHub also sets Actions workflow permissions,
   sets up GitHub Pages if applicable, and (for public repos) enables CodeQL code scanning's
@@ -84,7 +84,7 @@ both files entirely.
 
 Whether to wire up code coverage reporting: the Codecov GitHub Action on GitHub, or Azure
 Pipelines' built-in coverage publishing on Azure DevOps. This only plumbs the upload/publish
-step -- it expects a `coverage.xml` (Cobertura format) at the repo root, and doesn't produce
+step; it expects a `coverage.xml` (Cobertura format) at the repo root, and doesn't produce
 one itself. Your own test command (or a language-specific child template built from this one)
 needs to actually generate that file, e.g. `pytest-cov`'s `--cov-report=xml` for Python or
 Pester's `-CodeCoverage` for PowerShell.

--- a/template/{% if is_template %}docs{% endif %}/token-permissions.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/token-permissions.md.jinja
@@ -1,7 +1,7 @@
 # Token Permissions
 
 This doc details the minimum scopes/permissions needed to use this template, along with reasons
-why. Neither platform requires a prompted Personal Access Token for repo setup anymore -- both use
+why. Neither platform requires a prompted Personal Access Token for repo setup anymore; both use
 the platform's own CLI session instead (`gh auth login` / `az login`).
 
 Once you've created each secret/token below, run `mise run provision-secrets`: each value is
@@ -14,9 +14,9 @@ any time, e.g. to rotate a token.
 Both platforms' Copier update-check job needs a secret/variable called **APPRISE_URL**. Azure
 DevOps additionally needs it for the Renovate pipeline and the release/docs pipelines, since
 those merge without a human in the loop and notify on both successful auto-merge and on PR
-validation failing to pass. Unlike the tokens below, it isn't a scope to grant -- it's an
+validation failing to pass. Unlike the tokens below, it isn't a scope to grant; it's an
 [Apprise](https://github.com/caronc/apprise) notification URL pointing at wherever you want these
-notifications sent (email, Slack, Discord, ntfy, Pushover, and 80+ others -- see Apprise's own
+notifications sent (email, Slack, Discord, ntfy, Pushover, and 80+ others; see Apprise's own
 docs for the URL format for your service of choice).
 
 ## GitHub
@@ -25,16 +25,16 @@ docs for the URL format for your service of choice).
 
 Repo creation and configuration (labels, merge options, branch protection, Actions permissions,
 Pages) uses the [GitHub CLI](https://cli.github.com)'s own authenticated session rather than a
-prompted Personal Access Token -- see [Prerequisites](prerequisites.md). Default scopes (`repo`
+prompted Personal Access Token; see [Prerequisites](prerequisites.md). Default scopes (`repo`
 among them) are enough; no need for `gh auth login --scopes ...`. The initial `git push` is a
-separate matter -- `gh auth login`'s scopes don't cover pushing `.github/workflows/` files
+separate matter; `gh auth login`'s scopes don't cover pushing `.github/workflows/` files
 regardless, so that step uses Git Credential Manager's own login instead, not `gh`'s.
 
 ### Repo Maintenance PAT (Classic Token)
 
 For best security, create this token via [this link](https://github.com/settings/personal-access-tokens/new)
 and save it as a GitHub Actions secret on the repository called **REPO_MAINTENANCE_PAT**. This is
-separate from `gh auth login` above -- it's used on an ongoing basis by this project's own GitHub
+separate from `gh auth login` above; it's used on an ongoing basis by this project's own GitHub
 Actions workflows (Copier update checks, docs builds), not just at setup time.
 
 **Repository Access**: All repositories
@@ -50,9 +50,9 @@ NOTE: Fine-grained tokens are specifically **not** used, as they cannot open pul
 ### `az login` Permissions
 
 Repo creation and pipeline registration use the
-[Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)'s own authenticated session --
-see [Prerequisites](prerequisites.md). No PAT scopes to configure; the signed-in account just needs
+[Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)'s own authenticated session
+(see [Prerequisites](prerequisites.md)). No PAT scopes to configure; the signed-in account just needs
 enough permission in the target project to create repos and pipelines (typically **Project
 Administrator**, or an equivalent custom permission set covering `Code: Full` and
-`Build: Read & Execute`). The initial `git push` is a separate matter -- `az login` doesn't bridge
+`Build: Read & Execute`). The initial `git push` is a separate matter; `az login` doesn't bridge
 into git's credentials, so that step uses Git Credential Manager's own login instead.

--- a/template/{% if is_template %}scripts{% endif %}/integration_test_azdo.py
+++ b/template/{% if is_template %}scripts{% endif %}/integration_test_azdo.py
@@ -1,6 +1,6 @@
 """Create two throwaway repos from this template and verify them.
 
-Azure DevOps counterpart to integration_test_github.py -- see that file for the shared
+Azure DevOps counterpart to integration_test_github.py; see that file for the shared
 shape (create/verify, both repos left in place afterward for you to delete yourself).
 Diverges in a few real ways: no Settings App equivalent here, so nothing to poll for
 asynchronously; `az` also has no scope-introspection command the way `gh auth status`
@@ -11,19 +11,19 @@ GitHub, where deleting the repo deletes everything registered against it) has no
 bulk-delete UI for pipelines; and `az` has no cheap way to read a pipeline run's own
 step-level output the way `gh run view --json jobs` does, so Maint (Auto) - Copier
 Update Check is only checked for a successful run here, not whether it correctly
-detected an update -- that nuance stays on the manual checklist for this platform.
+detected an update; that nuance stays on the manual checklist for this platform.
 
-Always runs against HEAD -- this is meant to verify a release candidate on main is
+Always runs against HEAD; this is meant to verify a release candidate on main is
 good before cutting a release, not to smoke-test an arbitrary branch. Creates two
 repos every run, each covering a different scenario so a single run exercises more of
 the answer space, not the same fixed answers twice: Repo A is a plain `copier copy`
-with `code_coverage` on -- every automated check this script can run happens against
+with `code_coverage` on; every automated check this script can run happens against
 it. Repo B is copied at the last stable tag with `code_coverage` off, left there for
 you to run `mise run copier-update` (then `mise run migrate-azdo-pipeline-names`)
-against yourself -- deliberately not automated, see main()'s own docstring for why.
+against yourself; deliberately not automated, see main()'s own docstring for why.
 
 Every check this script runs prints its own PASS/FAIL line as it happens, plus a
-summary per repo at the end -- it never stops at the first failure, so one run gives
+summary per repo at the end; it never stops at the first failure, so one run gives
 the full picture. It only checks things that need a real Azure DevOps API call or a
 real pipeline run; anything `tests/` already covers by rendering locally (structure,
 Jinja/YAML validity, links, nav) isn't repeated here.
@@ -113,7 +113,7 @@ def check_azure_devops_extension() -> None:
     """Verify the azure-devops CLI extension is installed.
 
     `az devops`/`az repos`/`az pipelines` commands, if the extension isn't installed,
-    prompt interactively to install it ("Do you want to install it now? (Y/n):") --
+    prompt interactively to install it ("Do you want to install it now? (Y/n):"),
     which just hangs forever with no stdin attached (e.g. under `mise run` or in CI).
     Checking via `az extension list` first (a core command that doesn't itself need
     the extension) avoids ever triggering that prompt.
@@ -135,7 +135,7 @@ def check_azure_devops_extension() -> None:
 def check_access(org_url: str, project: str) -> None:
     """Verify the active az session can actually see the target project.
 
-    Not a scope check (az has no equivalent to `gh auth status`'s scope list) -- just
+    Not a scope check (az has no equivalent to `gh auth status`'s scope list); just
     confirms the token/session is valid and has at least read access, so a bad
     AZURE_DEVOPS_EXT_PAT fails here with a clear message instead of deep inside
     `copier copy`.
@@ -167,13 +167,13 @@ def check(failures: list[str], name: str, ok: bool, detail: str = "") -> None:
     """Record and print one named check's result immediately, without halting.
 
     Every automated check in this script goes through here so failures accumulate
-    instead of stopping the run at the first one -- a full run reports the complete
+    instead of stopping the run at the first one; a full run reports the complete
     picture, not just whatever happened to fail first.
     """
     if ok:
         print(f"  [PASS] {name}")
     else:
-        print(f"  [FAIL] {name}" + (f" -- {detail}" if detail else ""))
+        print(f"  [FAIL] {name}" + (f": {detail}" if detail else ""))
         failures.append(name)
 
 
@@ -204,7 +204,7 @@ def create(
     getting the question's own (always off) default.
 
     `--defaults` falls back to each question's own default for anything not covered
-    by an explicit -d below (currently author_name, zensical_target) -- without it,
+    by an explicit -d below (currently author_name, zensical_target); without it,
     copier drops into an interactive prompt for those. Explicit -d values below still
     take priority over --defaults regardless of order.
     """
@@ -248,7 +248,7 @@ def latest_stable_tag(source: str) -> str:
 
     Uses `git ls-remote --tags` so it works directly against `source` without a local
     clone. Matches strict `vX.Y.Z` tags only (excluding prereleases like
-    `v1.1.0-alpha.0`) and sorts by parsed version, not lexically -- a plain string
+    `v1.1.0-alpha.0`) and sorts by parsed version, not lexically; a plain string
     sort would put `v0.7.9` after `v0.7.20`.
 
     Returns:
@@ -303,7 +303,7 @@ def list_tags(org_url: str, project: str, repo_name: str) -> set[str]:
 
 CLEANUP_PIPELINES_SCRIPT = '''"""Delete every Azure Pipeline registered for {repo_name}.
 
-Written by integration_test_azdo.py -- not part of the template itself, and never
+Written by integration_test_azdo.py; not part of the template itself, and never
 committed to the repo it's dropped into. Azure DevOps has no bulk-delete UI for
 pipelines; each one otherwise has to be removed by hand through its own settings page.
 Run this before deleting {repo_name} itself.
@@ -364,7 +364,7 @@ def write_cleanup_script(dest: str, org_url: str, project: str, repo_name: str) 
     """Drop a standalone script into `dest` that deletes every pipeline for this repo.
 
     Self-contained (no import from this module) so it still works after this process
-    exits, whenever you're actually ready to delete the throwaway repo -- and never
+    exits, whenever you're actually ready to delete the throwaway repo; and never
     committed, since it has no reason to exist once the repo itself is gone.
     """
     Path(dest, "cleanup_pipelines.py").write_text(
@@ -386,7 +386,7 @@ def report_pr_validation_policy(
     """Report whether the PR-validation build-validation policy was actually applied.
 
     Only checks the policy configuration itself (existence, blocking, enabled, and
-    that it targets the pr_validation pipeline) -- not the Project Administrators
+    that it targets the pr_validation pipeline); not the Project Administrators
     bypass-permission grant alongside it. `az devops security permission`'s JSON
     output shape isn't documented clearly enough (no example response in Microsoft's
     own docs) to assert against confidently without a live org to verify against, so
@@ -460,7 +460,7 @@ def verify(
         one by name without looking it up again.
 
     Raises:
-        SystemExit: only if the repo itself can't be found -- every other assertion
+        SystemExit: only if the repo itself can't be found; every other assertion
             is recorded via check() instead, since a real value here doesn't prevent
             the rest of this script's checks from being meaningful.
 
@@ -481,7 +481,7 @@ def verify(
         "tsv",
     )
     if not repo_id:
-        raise SystemExit(f"Repo {repo_name!r} not found -- did create() fail?")
+        raise SystemExit(f"Repo {repo_name!r} not found; did create() fail?")
 
     pipelines = json.loads(
         az_value(
@@ -551,7 +551,7 @@ def wait_for_pipeline_run(
     """Poll a pipeline run until it finishes and return its result.
 
     Returns:
-        The run's result, e.g. "succeeded" or "failed" -- "timed out" if `timeout`
+        The run's result, e.g. "succeeded" or "failed"; "timed out" if `timeout`
         seconds pass without the run completing.
 
     """
@@ -638,7 +638,7 @@ def wait_for_new_pipeline_run(
 ) -> str:
     """Poll for a new run of a pipeline to appear after `before_id`.
 
-    A push-triggered Azure Pipeline run doesn't always register immediately --
+    A push-triggered Azure Pipeline run doesn't always register immediately:
     observed taking longer than a 60s budget in live testing, well before any
     step of the run itself even starts.
 
@@ -664,7 +664,7 @@ def provision_test_secrets(org_url: str, project: str, repo_name: str) -> None:
     """Set a placeholder APPRISE_URL variable on every pipeline that requires it.
 
     Mirrors `mise run provision-secrets`'s own `az pipelines variable create` calls
-    (see mise.toml.jinja) -- each pipeline needs its own copy, since Azure Pipelines
+    (see mise.toml.jinja); each pipeline needs its own copy, since Azure Pipelines
     variables are scoped per-pipeline, not project-wide the way GitHub secrets are.
     Points at a real, harmless HTTPS endpoint, not a fake host, so a pipeline that
     actually sends a notification doesn't fail on an unrelated delivery error.
@@ -702,7 +702,7 @@ def check_copier_update_check(
 ) -> None:
     """Dispatch Maint (Auto) - Copier Update Check and confirm it runs successfully.
 
-    Doesn't check whether it correctly detected an update either way -- see this
+    Doesn't check whether it correctly detected an update either way; see this
     module's own docstring for why that stays manual on this platform.
     """
     print("Checking Maint (Auto) - Copier Update Check...")
@@ -719,14 +719,14 @@ def check_noop_update(dest: str, vcs_ref: str, failures: list[str]) -> None:
     """Run `copier update` against an already-current repo and confirm it's a no-op.
 
     `--defaults` is safe here specifically because nothing changed since this repo was
-    copied -- there's no template diff to introduce a new question, so there's no risk
+    copied; there's no template diff to introduce a new question, so there's no risk
     of silently defaulting past a real prompt the way there would be for Repo B.
 
     `vcs_ref` must match whatever `create()` used for this repo: without an explicit
     ref, `copier update`/`check-update` falls back to resolving "the latest tag," and
     if there's no clean tag at the exact commit being tested, copier synthesizes a
     `git describe`-style pseudo-version string and then tries to `git clone --branch`
-    using that same string as if it were a real ref -- which fails outright.
+    using that same string as if it were a real ref; which fails outright.
     """
     print("Checking `copier update` is a no-op on an already-current repo...")
     run(
@@ -783,7 +783,7 @@ def check_renovate(
 def wait_for_pr_policy(org_url: str, pr_id: str) -> str:
     """Poll a PR's build-validation policy until it settles past queued/running.
 
-    `az repos pr policy list` takes no `--project` -- a PR ID is unique within the
+    `az repos pr policy list` takes no `--project`; a PR ID is unique within the
     whole organization, not scoped per-project the way a repo name is.
 
     Returns:
@@ -839,7 +839,7 @@ def open_pr_wait_and_merge(
     commit_message: str,
     filename: str,
 ) -> None:
-    """Open a normal, passing PR and merge it -- the only way real commits reach main.
+    """Open a normal, passing PR and merge it; the only way real commits reach main.
 
     Branch protection rejects a direct `git push` to main outright, even for the
     project owner (confirmed the hard way: TF402455 "Pushes to this branch are not
@@ -898,7 +898,7 @@ def open_pr_wait_and_merge(
         "--squash",
         "true",
         # Without this, Azure DevOps writes a generic "Merge pull request N from
-        # <branch> into main" squash commit message instead of the PR title -- unlike
+        # <branch> into main" squash commit message instead of the PR title; unlike
         # GitHub, which defaults a squash merge's commit message to the PR title.
         # knope's PrepareRelease step parses Conventional Commits from real git commit
         # messages, so a squashed test commit that loses its "fix:"/"feat:" prefix this
@@ -1029,7 +1029,7 @@ def knope_release_pr_title(org_url: str, project: str, repo_name: str) -> str | 
     """Look up the open knope/release PR's title, if one is open.
 
     The title (e.g. "chore: prepare release 0.0.1") encodes the version knope
-    computed -- unlike relying on "is a PR open at all" (one may already be open from
+    computed; unlike relying on "is a PR open at all" (one may already be open from
     the bootstrap-time v0.1.0 PR), it's the right signal for "did this merge actually
     change what's proposed."
 
@@ -1064,7 +1064,7 @@ def check_release_flow(
     """Exercise the real release flow: a no-op merge, then a real release and tag.
 
     Azure DevOps has a single Release (Auto) - Prepare & Publish Release pipeline
-    (unlike GitHub's split prepare/publish workflows) -- one pipeline handles both the
+    (unlike GitHub's split prepare/publish workflows); one pipeline handles both the
     push-to-main prepare step and the merge-triggered publish step, telling them apart
     via its own API check.
     """
@@ -1077,7 +1077,7 @@ def check_release_flow(
     # *first* automated run after that always recomputes the version from knope's own
     # default rules, changing the PR's content regardless of what triggered that run.
     # Absorb that one-time transition with a throwaway merge before testing that a
-    # docs-only merge is a true no-op -- otherwise the correction gets misattributed
+    # docs-only merge is a true no-op; otherwise the correction gets misattributed
     # to whichever commit happens to trigger the first automated run.
     prepare_before = latest_pipeline_run_id(org_url, project, pid)
     open_pr_wait_and_merge(
@@ -1093,7 +1093,7 @@ def check_release_flow(
     wait_for_pipeline_run(org_url, project, warmup_run_id)
 
     # A release PR may already be open here (e.g. the bootstrap-time v0.1.0 one), so
-    # "no PR is open" isn't the right no-op signal -- what actually matters is that a
+    # "no PR is open" isn't the right no-op signal; what actually matters is that a
     # docs-only merge doesn't change what version it proposes.
     docs_noop_before = knope_release_pr_title(org_url, project, repo_name)
     prepare_before = latest_pipeline_run_id(org_url, project, pid)
@@ -1112,7 +1112,7 @@ def check_release_flow(
         failures,
         "a docs-only merge keeps the release pipeline green",
         # `az repos pr create` always fails with TF401179 ("an active pull request
-        # ... already exists") once the first knope/release PR is open -- see the feat
+        # ... already exists") once the first knope/release PR is open; see the feat
         # merge check below for the full explanation. A docs-only commit that finds
         # nothing release-worthy can *also* legitimately surface as partiallySucceeded
         # (matching releasing.md's "shows a failed step but stays green overall" note
@@ -1144,10 +1144,10 @@ def check_release_flow(
         failures,
         "a feat merge's release pipeline succeeds",
         # `az repos pr create` always fails with TF401179 ("an active pull request
-        # ... already exists") once the first knope/release PR is open -- every push
+        # ... already exists") once the first knope/release PR is open; every push
         # after the first hits this, regardless of commit type. Azure DevOps still
         # refreshes the PR's title from the new commit despite that failed step (the
-        # final title -- and the eventual release -- come out correct), so this is a
+        # final title and the eventual release come out correct), so this is a
         # real but non-blocking imperfection, not a failure worth hard-failing on.
         result in ("succeeded", "partiallySucceeded"),
         result,
@@ -1231,11 +1231,11 @@ def check_release_flow(
 def check_prerelease_flow(
     org_url: str, project: str, repo_name: str, dest: str, failures: list[str]
 ) -> None:
-    """Exercise Release (Manual) - Create Prerelease -- a label, a dup, a new label."""
+    """Exercise Release (Manual) - Create Prerelease; a label, a dup, a new label."""
     print("Checking Release (Manual) - Create Prerelease...")
     name = f"[{repo_name}] Release (Manual) - Create Prerelease"
 
-    # PrepareRelease refuses to run with nothing to bump -- without a real commit
+    # PrepareRelease refuses to run with nothing to bump; without a real commit
     # since the last release, every dispatch below would fail with knope's own
     # "No packages are ready to release", not the behavior this is meant to check.
     open_pr_wait_and_merge(
@@ -1299,7 +1299,7 @@ def check_post_update(
 
     This is the second entry point (`--verify-update`): the update itself happens by
     hand, on your own schedule, so this script can't chain straight from creating the
-    repo into checking it -- see main()'s own docstring.
+    repo into checking it; see main()'s own docstring.
     """
     print(f"Checking {repo_name}'s update applied cleanly...")
     run("git", "fetch", cwd=dest)
@@ -1313,7 +1313,7 @@ def check_post_update(
         log,
     )
     # Copier's own update conflicts come from `git merge-file`, so they use the same
-    # markers as any other git conflict -- one grep catches both.
+    # markers as any other git conflict; one grep catches both.
     grep = run(
         "git",
         "grep",
@@ -1424,10 +1424,10 @@ def main() -> None:
 
     Both run every time, always at HEAD (this tool exists to verify a release
     candidate on main is good before cutting a release, not to smoke-test an
-    arbitrary branch). Repo A is a plain `copier copy` with `code_coverage` on --
+    arbitrary branch). Repo A is a plain `copier copy` with `code_coverage` on;
     every automated check this script can run happens against it. Repo B is copied at
     the last stable tag with `code_coverage` off, for you to run `mise run
-    copier-update` (then `mise run migrate-azdo-pipeline-names`) against yourself --
+    copier-update` (then `mise run migrate-azdo-pipeline-names`) against yourself,
     deliberately not automated: those are the exact commands, with the exact prompts,
     a real user gets, and running them by hand is the only way to see a new
     question's prompt land the way it actually would for them, not however this
@@ -1436,13 +1436,13 @@ def main() -> None:
 
     Once you've updated Repo B by hand, re-run this script with `--verify-update
     <repo> --local-path <path>` (also available as `mise run
-    integration-test-verify-update-azdo`) to check it applied cleanly -- see
+    integration-test-verify-update-azdo`) to check it applied cleanly; see
     docs/manual-verification-azdo.md's "Repo B" section.
 
     Raises:
         SystemExit: if `az` or its azure-devops extension aren't installed, if
             --org/--project are missing, or if any automated check failed (after
-            printing every check's result -- see check()).
+            printing every check's result; see check()).
 
     """
     parser = argparse.ArgumentParser(description=__doc__)
@@ -1450,7 +1450,7 @@ def main() -> None:
     parser.add_argument("--repo-prefix", help="This repo's own name")
     # usage_org/usage_project are set when this runs via `mise run
     # integration-test-azdo`, whose `usage` field defines matching flags (mise's own
-    # arg-parsing, not this one) -- mise passes them through as real env vars rather
+    # arg-parsing, not this one); mise passes them through as real env vars rather
     # than templating them into the command line, so it works the same regardless of
     # the invoking shell/platform (unlike e.g. POSIX `${var}` expansion, which cmd.exe
     # can't parse).
@@ -1563,7 +1563,7 @@ def main() -> None:
     print(
         f"\nLeaving {repo_a_name} ({dest_a}) and {repo_b_name} ({dest_b}) in place. "
         "Run `python cleanup_pipelines.py` in each directory before deleting the "
-        f"repos -- Azure DevOps has no bulk-delete UI for pipelines. {repo_b_name} "
+        f"repos; Azure DevOps has no bulk-delete UI for pipelines. {repo_b_name} "
         f"is still at {old_ref}; cd into {dest_b} and run `mise run copier-update` "
         "yourself to test the update path, then `mise run "
         f"integration-test-verify-update-azdo -- --repo {repo_b_name} --local-path "

--- a/template/{% if is_template %}scripts{% endif %}/integration_test_github.py
+++ b/template/{% if is_template %}scripts{% endif %}/integration_test_github.py
@@ -1,21 +1,21 @@
 """Create two throwaway repos from this template and verify them.
 
-Run via `mise run integration-test-gh` -- a human's own gh/GCM session, both repos
+Run via `mise run integration-test-gh`; a human's own gh/GCM session, both repos
 left in place afterward for inspection (delete them yourself when you're done). Not
 templated itself; the caller passes this repo's own source URL and name as arguments,
 so there's nothing here for Jinja to render.
 
-Always runs against HEAD -- this is meant to verify a release candidate on main is
+Always runs against HEAD; this is meant to verify a release candidate on main is
 good before cutting a release, not to smoke-test an arbitrary branch. Creates two
 repos every run, each covering a different scenario so a single run exercises more of
 the answer space, not the same fixed answers twice: Repo A is a plain `copier copy`
 with `zensical_target: GitHub Pages` and `code_coverage` on; Repo B is copied at the
 last stable tag with `zensical_target: docs-site Directory in Repo` and
 `code_coverage` off, left there for you to run `mise run copier-update` against
-yourself -- deliberately not automated, see main()'s own docstring for why.
+yourself; deliberately not automated, see main()'s own docstring for why.
 
 Every check this script runs prints its own PASS/FAIL line as it happens, plus a
-summary per repo at the end -- it never stops at the first failure, so one run gives
+summary per repo at the end; it never stops at the first failure, so one run gives
 the full picture. It only checks things that need a real GitHub API call or a real
 pipeline run; anything `tests/` already covers by rendering locally (structure,
 Jinja/YAML validity, links, nav) isn't repeated here.
@@ -34,7 +34,7 @@ import tempfile
 import time
 from pathlib import Path
 
-# Default `gh auth login` scopes cover both -- see docs/token-permissions.md.
+# Default `gh auth login` scopes cover both; see docs/token-permissions.md.
 REQUIRED_SCOPES = ("repo", "workflow")
 
 # Must match _tasks' project_description -d flag in create() below.
@@ -104,8 +104,8 @@ def check_scopes() -> None:
     """Verify the active gh token has every scope this script needs.
 
     `gh auth status` reports a classic token's granted scopes (sourced from GitHub's
-    own X-OAuth-Scopes API response) as a human-readable "Token scopes: 'a', 'b'" line
-    -- there's no dedicated --json field for this, so this greps that line instead of
+    own X-OAuth-Scopes API response) as a human-readable "Token scopes: 'a', 'b'" line;
+    there's no dedicated --json field for this, so this greps that line instead of
     querying the API directly a second time.
 
     Raises:
@@ -126,13 +126,13 @@ def check(failures: list[str], name: str, ok: bool, detail: str = "") -> None:
     """Record and print one named check's result immediately, without halting.
 
     Every automated check in this script goes through here so failures accumulate
-    instead of stopping the run at the first one -- a full run reports the complete
+    instead of stopping the run at the first one; a full run reports the complete
     picture, not just whatever happened to fail first.
     """
     if ok:
         print(f"  [PASS] {name}")
     else:
-        print(f"  [FAIL] {name}" + (f" -- {detail}" if detail else ""))
+        print(f"  [FAIL] {name}" + (f": {detail}" if detail else ""))
         failures.append(name)
 
 
@@ -161,7 +161,7 @@ def create(
     `github_username` is pinned to the already-resolved `owner` rather than left to
     auto-detect from local git config: copier.yml.jinja's `.github/settings.yml`
     content (e.g. `homepage`) is templated from `github_repo_owner`, which defaults to
-    `github_username` -- letting that auto-detect could silently diverge from the
+    `github_username`; letting that auto-detect could silently diverge from the
     account gh actually authenticated as, breaking verify() for reasons unrelated to
     what it's actually trying to test.
 
@@ -170,7 +170,7 @@ def create(
     silently both getting whatever the question's own default is.
 
     `--defaults` falls back to each question's own default for anything not covered
-    by an explicit -d below (currently github_org, author_name) -- without it, copier
+    by an explicit -d below (currently github_org, author_name); without it, copier
     drops into an interactive prompt for those. Explicit -d values below still take
     priority over --defaults regardless of order.
     """
@@ -214,7 +214,7 @@ def latest_stable_tag(source: str) -> str:
 
     Uses `git ls-remote --tags` so it works directly against `source` without a local
     clone. Matches strict `vX.Y.Z` tags only (excluding prereleases like
-    `v1.1.0-alpha.0`) and sorts by parsed version, not lexically -- a plain string
+    `v1.1.0-alpha.0`) and sorts by parsed version, not lexically; a plain string
     sort would put `v0.7.9` after `v0.7.20`.
 
     Returns:
@@ -320,10 +320,10 @@ def dispatch_workflow(
 def open_pr_wait_and_merge(
     repo: str, dest: str, branch: str, commit_message: str, filename: str
 ) -> None:
-    """Open a normal, passing PR and merge it -- the only way real commits reach main.
+    """Open a normal, passing PR and merge it; the only way real commits reach main.
 
     Branch protection requires every change to go through a PR, even for the repo
-    owner -- a direct `git push` to main is rejected outright once the ruleset is
+    owner; a direct `git push` to main is rejected outright once the ruleset is
     live (confirmed the hard way: an earlier version of this script tried exactly
     that). This also mirrors how release-auto-preparereleasepr.yml actually gets
     triggered in practice: by the push GitHub generates when a PR merges, not by
@@ -363,13 +363,13 @@ def wait_for_pr_checks(repo: str, pr_number: str) -> None:
 
     A force-push in quick succession (e.g. a branch updated twice back-to-back) can
     leave a stale `CANCELLED` entry alongside the newer run's result for the same
-    check name -- `test-auto-prvalidation.yml`'s own concurrency group cancels the
+    check name; `test-auto-prvalidation.yml`'s own concurrency group cancels the
     superseded run. Only the most recent entry per check name reflects the PR's
     actual current state, so older duplicates are dropped before evaluating success.
 
     A dedupe pass alone isn't enough: a check can be observed as COMPLETED
     (cancelled) in the brief window before its superseding run has even been
-    created, let alone registered in the rollup -- a cancelled run and its
+    created, let alone registered in the rollup; a cancelled run and its
     replacement's SUCCESS have been observed completing within the same second. So
     this only accepts an "all complete" result once the exact same snapshot is
     observed on two consecutive polls, giving a just-created superseding run a
@@ -414,7 +414,7 @@ def wait_for_run(repo: str, run_id: int) -> str:
 
     `check=False`: a failing run makes `gh run watch --exit-status` exit non-zero,
     which is an expected outcome for some callers (e.g. a deliberately-broken PR), not
-    a bug in this script -- the caller decides what conclusion was actually wanted.
+    a bug in this script; the caller decides what conclusion was actually wanted.
 
     Returns:
         The run's conclusion, e.g. "success" or "failure".
@@ -457,9 +457,9 @@ def report_settings_checks(
 ) -> None:
     """Report each part of .github/settings.yml the Settings App should have applied.
 
-    Covers the `repository`, `labels`, `rulesets`, and `environments` blocks -- every
+    Covers the `repository`, `labels`, `rulesets`, and `environments` blocks; every
     top-level key that file actually sets, not just a sample of them. The
-    `github-pages` environment only exists when `zensical_ghpages` is true --
+    `github-pages` environment only exists when `zensical_ghpages` is true:
     settings.yml.jinja only declares it in that case.
     """
     repo_data = json.loads(
@@ -530,7 +530,7 @@ def report_settings_checks(
 def settings_synced(repo: str, homepage: str, *, zensical_ghpages: bool) -> bool:
     """Check whether the Settings App has applied every part of .github/settings.yml.
 
-    Used only to decide when the polling loop in verify() can stop -- the actual
+    Used only to decide when the polling loop in verify() can stop; the actual
     per-field results get reported once, afterward, by report_settings_checks().
 
     Returns:
@@ -603,7 +603,7 @@ def verify(
     `zensical_target: GitHub Pages`.
 
     Raises:
-        SystemExit: only if the repo itself can't be found -- every other assertion
+        SystemExit: only if the repo itself can't be found; every other assertion
             is recorded via check() instead, since a real value here doesn't prevent
             the rest of this script's checks from being meaningful.
 
@@ -613,7 +613,7 @@ def verify(
         "gh", "repo", "view", repo, "--json", "visibility", check=False, capture=True
     )
     if repo_view.returncode != 0:
-        raise SystemExit(f"Repo {repo!r} not found -- did create() fail?")
+        raise SystemExit(f"Repo {repo!r} not found; did create() fail?")
     visibility = json.loads(repo_view.stdout)["visibility"]
     check(
         failures,
@@ -635,10 +635,10 @@ def verify(
 
     # Labels and the branch ruleset come from .github/settings.yml, applied
     # asynchronously by the Settings GitHub App (https://github.com/apps/settings)
-    # reacting to the push above -- not something this script sets directly, so this
+    # reacting to the push above; not something this script sets directly, so this
     # polls rather than checking once. Requires that app be installed on the
     # authenticated account with access to all repositories (a new repo isn't
-    # automatically visible to an app installed on "only select repositories") -- see
+    # automatically visible to an app installed on "only select repositories"); see
     # docs/token-permissions.md.
     for attempt in range(12):
         if settings_synced(repo, homepage, zensical_ghpages=zensical_ghpages):
@@ -647,7 +647,7 @@ def verify(
         time.sleep(10)
     else:
         print(
-            "Settings App sync: not observed within 120s -- is it installed on this "
+            "Settings App sync: not observed within 120s; is it installed on this "
             "account with access to all repositories?"
         )
     report_settings_checks(repo, homepage, failures, zensical_ghpages=zensical_ghpages)
@@ -675,8 +675,8 @@ def provision_test_secrets(repo: str) -> None:
     REPO_MAINTENANCE_PAT: Release (Auto): Prepare Release PR pushes to `knope/release`
     and opens/updates a PR against it. A push authenticated as the default
     `GITHUB_TOKEN` (i.e. actor `github-actions[bot]`) leaves that PR's required `tests`
-    status check permanently stuck in GitHub's `action_required` state -- pending a
-    human manually approving the run in the Actions tab -- which blocks branch
+    status check permanently stuck in GitHub's `action_required` state; pending a
+    human manually approving the run in the Actions tab; which blocks branch
     protection from ever letting it merge. Reuses this script's own `gh` auth token
     (the same real-user identity already pushing the other test branches, which never
     hit this gate) so the release flow can be exercised the same way a real repo's own
@@ -717,7 +717,7 @@ def check_copier_update_check(
     )
     notify_step = step_conclusion(repo, run_id, "Notify if Update is Available")
     # Whether the step *ran* (its `if:` is gated on update_available), not whether
-    # its own delivery succeeded -- a real notification failure (bad endpoint, etc.)
+    # its own delivery succeeded; a real notification failure (bad endpoint, etc.)
     # would otherwise look identical to "no update was detected".
     detected_available = notify_step not in (None, "skipped")
     check(
@@ -737,11 +737,11 @@ def check_noop_update(dest: str, vcs_ref: str, failures: list[str]) -> None:
     """Run `copier update` against an already-current repo and confirm it's a no-op.
 
     `--defaults` is safe here specifically because nothing changed since this repo was
-    copied -- there's no template diff to introduce a new question, so there's no risk
+    copied; there's no template diff to introduce a new question, so there's no risk
     of silently defaulting past a real prompt the way there would be for Repo B.
 
     `vcs_ref` must match whatever `create()` used for this repo: without an explicit
-    `--vcs-ref`, `copier update` targets the latest release *tag*, not HEAD -- if
+    `--vcs-ref`, `copier update` targets the latest release *tag*, not HEAD; if
     main has commits past the last release (the normal case), that's an earlier point
     than what this repo was actually created at, and copier has no sane way to
     "update" backwards to it.
@@ -771,7 +771,7 @@ def check_repo_health_check(repo: str, failures: list[str]) -> None:
     """Dispatch Maint (Auto): Repo Health Check and confirm it completes clean.
 
     Covers both jobs (link-check and the REPO_MAINTENANCE_PAT expiration check) via
-    the overall run conclusion -- a real near-expiry PAT to exercise the actual
+    the overall run conclusion; a real near-expiry PAT to exercise the actual
     warning/notification path isn't something this throwaway repo has, so that part
     stays on the manual verification checklist.
     """
@@ -898,7 +898,7 @@ def knope_release_pr_title(repo: str) -> str | None:
     """Look up the open knope/release PR's title, if one is open.
 
     The title (e.g. "chore: prepare release 0.0.1") encodes the version knope
-    computed -- unlike the PR's head commit SHA, it doesn't change just because
+    computed; unlike the PR's head commit SHA, it doesn't change just because
     `autoupdate-knope-pr` recreates the branch from a fresh main HEAD every run, so
     it's the right signal for "did this merge actually change what's proposed."
 
@@ -932,7 +932,7 @@ def check_release_flow(repo: str, dest: str, failures: list[str]) -> None:
     # *first* automated run after that always recomputes the version from knope's own
     # default rules, changing the PR's content regardless of what triggered that run.
     # Absorb that one-time transition with a throwaway merge before testing that a
-    # docs-only merge is a true no-op -- otherwise the correction gets misattributed
+    # docs-only merge is a true no-op; otherwise the correction gets misattributed
     # to whichever commit happens to trigger the first automated run.
     prepare_before = latest_run_id(repo, "release-auto-preparereleasepr.yml")
     open_pr_wait_and_merge(
@@ -948,7 +948,7 @@ def check_release_flow(repo: str, dest: str, failures: list[str]) -> None:
     wait_for_run(repo, warmup_run_id)
 
     # A release PR may already be open here (e.g. the bootstrap-time v0.1.0 one), so
-    # "no PR is open" isn't the right no-op signal -- what actually matters is that a
+    # "no PR is open" isn't the right no-op signal; what actually matters is that a
     # docs-only merge doesn't change what version it proposes.
     docs_noop_before = knope_release_pr_title(repo)
     prepare_before = latest_run_id(repo, "release-auto-preparereleasepr.yml")
@@ -1068,7 +1068,7 @@ def check_release_flow(repo: str, dest: str, failures: list[str]) -> None:
 
         # Publishing a release fires a `release: published` event that
         # docs-auto-zensical.yml listens for (it publishes the "latest" Pages docs
-        # alias) -- wait for it here so check_repo_health_check(), which runs later,
+        # alias); wait for it here so check_repo_health_check(), which runs later,
         # isn't racing a Pages deployment that hasn't happened yet.
         zensical_run_id = wait_for_new_run(
             repo, "docs-auto-zensical.yml", zensical_before
@@ -1083,10 +1083,10 @@ def check_release_flow(repo: str, dest: str, failures: list[str]) -> None:
 
 
 def check_prerelease_flow(repo: str, dest: str, failures: list[str]) -> None:
-    """Exercise Release (Manual): Create Prerelease -- a label, a dup, a new label."""
+    """Exercise Release (Manual): Create Prerelease; a label, a dup, a new label."""
     print("Checking Release (Manual): Create Prerelease...")
 
-    # PrepareRelease refuses to run with nothing to bump -- without a real commit
+    # PrepareRelease refuses to run with nothing to bump; without a real commit
     # since the last release, every dispatch below would fail with knope's own
     # "No packages are ready to release", not the behavior this is meant to check.
     open_pr_wait_and_merge(
@@ -1152,7 +1152,7 @@ def check_post_update(repo: str, dest: str, failures: list[str]) -> None:
 
     This is the second entry point (`--verify-update`): the update itself happens by
     hand, on your own schedule, so this script can't chain straight from creating the
-    repo into checking it -- see main()'s own docstring.
+    repo into checking it; see main()'s own docstring.
     """
     print(f"Checking {repo}'s update applied cleanly...")
     run("git", "fetch", cwd=dest)
@@ -1166,7 +1166,7 @@ def check_post_update(repo: str, dest: str, failures: list[str]) -> None:
         log,
     )
     # Copier's own update conflicts come from `git merge-file`, so they use the same
-    # markers as any other git conflict -- one grep catches both.
+    # markers as any other git conflict; one grep catches both.
     grep = run(
         "git",
         "grep",
@@ -1236,10 +1236,10 @@ def main() -> None:
     Both run every time, always at HEAD (this tool exists to verify a release
     candidate on main is good before cutting a release, not to smoke-test an
     arbitrary branch). Repo A is a plain `copier copy` with `zensical_target: GitHub
-    Pages` and `code_coverage` on -- every automated check this script can run
+    Pages` and `code_coverage` on; every automated check this script can run
     happens against it. Repo B is copied at the last stable tag with
     `zensical_target: docs-site Directory in Repo` and `code_coverage` off, for you to
-    run `mise run copier-update` against yourself -- deliberately not automated:
+    run `mise run copier-update` against yourself; deliberately not automated:
     that's the exact command, with the exact prompts, a real user gets, and running it
     by hand is the only way to see a new question's prompt land the way it actually
     would for them, not however this script happened to answer it. Both repos are
@@ -1247,12 +1247,12 @@ def main() -> None:
 
     Once you've updated Repo B by hand, re-run this script with `--verify-update
     <repo> --local-path <path>` (also available as `mise run
-    integration-test-verify-update-gh`) to check it applied cleanly -- see
+    integration-test-verify-update-gh`) to check it applied cleanly; see
     docs/manual-verification-github.md's "Repo B" section.
 
     Raises:
         SystemExit: if required arguments are missing, or if any automated check
-            failed (after printing every check's result -- see check()).
+            failed (after printing every check's result; see check()).
 
     """
     parser = argparse.ArgumentParser(description=__doc__)
@@ -1318,7 +1318,7 @@ def main() -> None:
     check_failing_tests_block_merge(repo_a, dest_a, failures_a)
     check_release_flow(repo_a, dest_a, failures_a)
     # Run last: a GitHub Pages repo's own homepage link (in README.md) 404s until the
-    # first Pages deployment finishes propagating -- by now enough real wall-clock
+    # first Pages deployment finishes propagating; by now enough real wall-clock
     # time and several PR/merge cycles have passed for that to be reliably live,
     # rather than racing it right after repo creation.
     check_repo_health_check(repo_a, failures_a)
@@ -1349,7 +1349,7 @@ def main() -> None:
     report(f"Repo B ({repo_b}, before updating)", failures_b)
 
     print(
-        f"\nLeaving {repo_a} ({dest_a}) and {repo_b} ({dest_b}) in place -- delete "
+        f"\nLeaving {repo_a} ({dest_a}) and {repo_b} ({dest_b}) in place; delete "
         f"them yourself when you're done. {repo_b} is still at {old_ref}; cd into "
         f"{dest_b} and run `mise run copier-update` yourself to test the update path, "
         "then `mise run integration-test-verify-update-gh -- --repo "

--- a/template/{% if is_template %}tests{% endif %}/answer_matrix.py
+++ b/template/{% if is_template %}tests{% endif %}/answer_matrix.py
@@ -1,6 +1,6 @@
 """Boundary answer combinations shared by every test module in this directory.
 
-Edit this file when you add, remove, or rename a Copier question in copier.yml -- each
+Edit this file when you add, remove, or rename a Copier question in copier.yml; each
 entry should be a real, reachable combination (respecting copier.yml's
 `when:`/`validator:` constraints, e.g. `Public` + `MIT` isn't valid on Azure DevOps)
 that exercises a distinct rendering path. This file is repo-specific by design; the
@@ -126,7 +126,7 @@ INVALID_ANSWER_MATRIX = [
 # with the reason it's a deliberate gap rather than an oversight.
 COVERAGE_EXEMPT_QUESTIONS = {
     # "Create Repo"/"Set Repo Rules" only gate which _tasks run (real GitHub/Azure
-    # DevOps API calls via should_create_repo/should_set_repo_settings) -- they never
+    # DevOps API calls via should_create_repo/should_set_repo_settings); they never
     # affect rendered file content, and this suite always renders with --skip-tasks.
     # COMMON pins this to "None" everywhere specifically to keep tests offline.
     "repo_setup_actions",

--- a/template/{% if is_template %}tests{% endif %}/conftest.py
+++ b/template/{% if is_template %}tests{% endif %}/conftest.py
@@ -1,7 +1,7 @@
 """Shared fixtures and helpers for rendering this template against real Copier.
 
 Generic by design: nothing here hardcodes this repo's specific doc set or question
-values -- see answer_matrix.py for the repo-specific piece, which a child template
+values; see answer_matrix.py for the repo-specific piece, which a child template
 should edit alongside its own copier.yml changes.
 """
 
@@ -48,7 +48,7 @@ def _run(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProces
     """Run subprocess.run with output always captured as UTF-8 text.
 
     Windows' default console encoding (cp1252) can't decode tool output containing
-    e.g. emoji or box-drawing characters (lychee's summary, for one) -- that mismatch
+    e.g. emoji or box-drawing characters (lychee's summary, for one); that mismatch
     crashes the background reader thread and leaves stdout/stderr as None instead of
     raising cleanly.
 
@@ -81,7 +81,7 @@ def _git_init_repo(path: Path) -> None:
     """Init a throwaway git repo at `path` with a fixed local identity.
 
     Needed because `copier update` requires both the source and the destination to be
-    git repositories -- it records `_commit` from the source at copy time and uses git
+    git repositories; it records `_commit` from the source at copy time and uses git
     to detect local destination changes when applying an update.
     """
     path.mkdir(parents=True, exist_ok=True)
@@ -113,11 +113,11 @@ def _assemble_source(repo_root: Path, dest: Path) -> None:
 
     Deliberately does not copy this repo's own root copier.yml: that file is dogfooded
     output, refreshed only by an occasional `copier update`, so it lags behind
-    uncommitted or just-committed edits under template/ -- exactly the edits this suite
+    uncommitted or just-committed edits under template/; exactly the edits this suite
     exists to catch. When template/ contains a self-hosting conditional copier.yml (a
     template that, like this one, supports generating child templates), that file's
-    non-raw header is rendered with stub values -- nothing in these tests inspects
-    parent_template_name/url -- while its `{% raw %}...{% endraw %}` body (the real
+    non-raw header is rendered with stub values; nothing in these tests inspects
+    parent_template_name/url; while its `{% raw %}...{% endraw %}` body (the real
     question set) passes through unprocessed, exactly as Copier itself would render it
     into a child's copier.yml.
     """
@@ -167,7 +167,7 @@ def _assemble_update_scratch_repo(repo_root: Path, old_tag: str, dest: Path) -> 
     """Build a 2-commit copier source for testing the update path: old_tag -> current.
 
     Commit 1 is `repo_root`'s real, historical state at `old_tag` (its actual root
-    copier.yml as released, not synthesized) -- exactly what a real user updating from
+    copier.yml as released, not synthesized); exactly what a real user updating from
     that release would have used as their template source. Commit 2 (HEAD) is the
     current on-disk template/ contents, assembled the same way _assemble_source builds
     it for the copy-only tests, so uncommitted edits are covered here too.
@@ -226,7 +226,7 @@ def update_source(tmp_path_factory):
     """
     old_tag = _latest_tag(REPO_ROOT)
     if old_tag is None:
-        pytest.skip("No git tags found -- nothing to update from yet.")
+        pytest.skip("No git tags found; nothing to update from yet.")
     src = tmp_path_factory.mktemp("update-source")
     _assemble_update_scratch_repo(REPO_ROOT, old_tag, src)
     return src, old_tag

--- a/template/{% if is_template %}tests{% endif %}/test_answer_matrix_coverage.py
+++ b/template/{% if is_template %}tests{% endif %}/test_answer_matrix_coverage.py
@@ -1,7 +1,7 @@
 """Checks answer_matrix.py's own completeness against copier.yml's real question set.
 
 Generic by design: parses whatever copier.yml actually defines, rather than hardcoding
-this repo's specific question names -- see answer_matrix.py for the repo-specific
+this repo's specific question names; see answer_matrix.py for the repo-specific
 answer data these checks audit, including COVERAGE_EXEMPT_QUESTIONS for any question
 that has a real, deliberate reason not to be fully exercised here.
 """
@@ -55,7 +55,7 @@ def test_answer_matrix_covers_all_choices(template_source):
 
     A question with N choices but only ever answered with one of them means the other
     N-1 code paths it gates (`when:`/Jinja `{% if %}` branches keyed on that value)
-    never get rendered by this suite at all -- silently, since nothing else here would
+    never get rendered by this suite at all; silently, since nothing else here would
     notice a whole branch just never ran.
     """
     questions = _load_questions(template_source)
@@ -79,7 +79,7 @@ def test_answer_matrix_covers_all_choices(template_source):
 def test_warn_on_unanswered_required_questions(template_source):
     """Warn about a no-default question that answer_matrix.py never explicitly answers.
 
-    Copier questions without a `default:` are required -- `copier copy --defaults`
+    Copier questions without a `default:` are required; `copier copy --defaults`
     (used throughout this suite) raises `ValueError: Question "X" is required` if such
     a question isn't supplied via `-d`. The render tests already fail hard when that
     happens; this is a faster, more specific pointer at *which* question is the gap,
@@ -94,7 +94,7 @@ def test_warn_on_unanswered_required_questions(template_source):
         if "default" not in question and name not in answered_keys:
             warnings.warn(
                 f"Copier question {name!r} has no default and isn't explicitly "
-                "answered by any answer_matrix.py combination -- `copier copy "
+                "answered by any answer_matrix.py combination; `copier copy "
                 '--defaults` will fail with "Question is required" until it is.',
                 stacklevel=1,
             )

--- a/template/{% if is_template %}tests{% endif %}/test_content.py
+++ b/template/{% if is_template %}tests{% endif %}/test_content.py
@@ -1,7 +1,7 @@
 """Checks content/config consistency in the rendered template, not the rendering itself.
 
 Generic by design: every check here operates on whatever actually got rendered, rather
-than hardcoding this repo's specific doc set -- see answer_matrix.py for the
+than hardcoding this repo's specific doc set; see answer_matrix.py for the
 repo-specific piece, which a child template should edit alongside its own copier.yml
 changes.
 """
@@ -117,7 +117,7 @@ def _entry_tool(entry: str) -> str | None:
         that isn't backed by a mise-managed CLI at all).
 
     """
-    prefix = "mise x -- "
+    prefix = "mise x; "
     if not entry.startswith(prefix):
         return None
     return entry[len(prefix) :].split()[0]
@@ -129,7 +129,7 @@ def _check_hook_tools_available(prek_toml: Path, mise_toml: Path) -> list[str]:
     prek.toml.jinja gates each hook behind the same conditions as its tool's entry in
     mise.toml.jinja (e.g. ruff-check/ruff-format and `is_template`, actionlint and
     `is_template or using_github`) specifically so this holds unconditionally for every
-    hook that's actually present in a given render -- no need to guess whether a hook
+    hook that's actually present in a given render; no need to guess whether a hook
     would find a matching file first. This is exactly the shape of bug that once let
     `actionlint` go missing from mise.toml for an Azure DevOps-hosted Template project.
 
@@ -178,7 +178,7 @@ def _task_command_text(task: dict | str) -> str:
     """Flatten one _tasks entry's command into a single searchable string.
 
     A `command:` value is either a plain string or a list of argv parts (Copier runs
-    the latter with shell=False) -- either way, joining into one string is enough for
+    the latter with shell=False); either way, joining into one string is enough for
     substring checks, without needing to know which form a given task uses.
 
     Returns:
@@ -193,7 +193,7 @@ def _check_azdo_pipelines_registered(dest: Path) -> list[str]:
     """Verify every .azurepipelines/*.yml file has a matching az pipelines create task.
 
     copier.yml.jinja hardcodes one explicit `az pipelines create --yml-path
-    .azurepipelines/<file>` _tasks entry per pipeline file -- a dynamic loop isn't
+    .azurepipelines/<file>` _tasks entry per pipeline file; a dynamic loop isn't
     possible in Copier's static _tasks list, so nothing else stops a newly-added
     pipeline file from silently never getting registered.
 

--- a/template/{% if is_template %}tests{% endif %}/test_render.py
+++ b/template/{% if is_template %}tests{% endif %}/test_render.py
@@ -2,7 +2,7 @@
 
 Generic by design: every check here operates on whatever actually got rendered (globbing
 for file types, checking for known top-level files) rather than hardcoding this repo's
-specific doc set or question values -- see answer_matrix.py for the repo-specific piece,
+specific doc set or question values; see answer_matrix.py for the repo-specific piece,
 which a child template should edit alongside its own copier.yml changes.
 """
 
@@ -16,7 +16,7 @@ from answer_matrix import ANSWER_MATRIX
 from conftest import _git_commit_all, _git_init_repo, _render, _run
 
 # VS Code parses these specific files as JSONC (comments and trailing commas allowed),
-# never as strict JSON -- see
+# never as strict JSON; see
 # https://code.visualstudio.com/docs/languages/json#_json-with-comments.
 _VSCODE_JSONC_FILES = {
     "settings.json",
@@ -109,7 +109,7 @@ def _check_all(root: Path, *, zensical: bool = True) -> list[str]:
 
     `zensical` is skippable: `test_update_from_last_tag` renders the same combo
     `test_render_combination` already builds docs for, just via `copier update`
-    instead of a fresh copy -- re-running the (comparatively slow) zensical build
+    instead of a fresh copy; re-running the (comparatively slow) zensical build
     there would only re-confirm docs content that hasn't changed, not exercise
     anything update-path-specific.
 
@@ -150,7 +150,7 @@ def test_update_from_last_tag(update_source, tmp_path, answers):
     dest = tmp_path / "out"
 
     # Some answer values are only valid after a specific rename in this repo's own
-    # history -- see answer_matrix.py's "_old_tag_overrides" for which ones and why.
+    # history; see answer_matrix.py's "_old_tag_overrides" for which ones and why.
     # The old tag can't recognize the current value, so the initial copy-at-old-tag
     # has to use whatever value actually was valid then; the update step below still
     # uses the current answers, so it also exercises the rename itself.

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/docs-auto-zensical.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/docs-auto-zensical.yml.jinja
@@ -205,7 +205,7 @@ stages:
           - pwsh: |
               if ("$(PR_VALIDATION_STATUS)" -ne "approved") {
                 apprise -i html -t "[$env:BUILD_REPOSITORY_NAME] Docs PR Needs Manual Attention" -b "PR #$(PULL_REQUEST_ID) ($(PR_TITLE)) did not pass PR validation (status: $(PR_VALIDATION_STATUS)) and was not merged automatically. Please review it manually." $env:APPRISE_URL
-                throw "PR validation did not succeed (status: $(PR_VALIDATION_STATUS)) -- leaving PR #$(PULL_REQUEST_ID) open for manual review."
+                throw "PR validation did not succeed (status: $(PR_VALIDATION_STATUS)); leaving PR #$(PULL_REQUEST_ID) open for manual review."
               }
 
               $MergeCommitMessage = "$(PR_TITLE)"

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/maint-auto-renovate.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/maint-auto-renovate.yml.jinja
@@ -7,7 +7,7 @@ trigger:
 
 schedules:
   # Matches renovate.json's own "schedule": ["* 0 1 * *"] window (once a month, day 1,
-  # hour 0 UTC) -- unlike Renovate's schedule syntax, Azure Pipelines cron is standard
+  # hour 0 UTC); unlike Renovate's schedule syntax, Azure Pipelines cron is standard
   # cron with real minute granularity, so this fires once, directly in that window,
   # rather than needing to poll daily.
   - cron: 0 0 1 * *

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/migrate_pipeline_names.py.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/migrate_pipeline_names.py.jinja
@@ -1,11 +1,11 @@
 """Fix up this repo's Azure Pipeline registrations after a naming-scheme rename.
 
 `copier update` renames `.azurepipelines/*.yml` files on disk (ordinary template-diff
-behavior), but it can't touch pipeline *registrations* already living in Azure DevOps --
+behavior), but it can't touch pipeline *registrations* already living in Azure DevOps:
 those are live objects the original `_tasks` bootstrap created via `az pipelines
 create`, and `_tasks` only ever run on a fresh `copier copy`, never on `update`. Run
 this once after a `copier update` that renamed pipelines, to repoint each existing
-registration at its new name and YAML path in place -- preserving its ID, run history,
+registration at its new name and YAML path in place; preserving its ID, run history,
 and any manually-set variables (e.g. APPRISE_URL, set via `mise run provision-secrets`)
 instead of losing them to a delete-and-recreate.
 
@@ -27,7 +27,7 @@ REPO_NAME = "{{ repo_name }}"
 
 # (old display name, new display name, new yml-path relative to the repo root). Pulled
 # directly from copier.yml's `az pipelines create` _tasks entries as of the rename that
-# introduced this script -- a future rename should add its own migration rather than
+# introduced this script; a future rename should add its own migration rather than
 # extend this table.
 MIGRATIONS = (
     (
@@ -65,7 +65,7 @@ MIGRATIONS = (
 
 # Renamed "Maint (Auto) - Link Check" to "Maint (Auto) - Repo Health Check" when a
 # REPO_MAINTENANCE_PAT expiration check (GitHub-only) got folded into the equivalent
-# GitHub workflow -- kept separate from MIGRATIONS above per that table's own note:
+# GitHub workflow; kept separate from MIGRATIONS above per that table's own note:
 # its "old" names are the pre-unified-naming-scheme originals, not a name a previous
 # migration already produced, so mixing this rename into it would be misleading.
 MIGRATIONS_REPO_HEALTH_CHECK = (
@@ -128,7 +128,7 @@ def check_azure_devops_extension() -> None:
     """Verify the azure-devops CLI extension is installed.
 
     `az devops`/`az repos`/`az pipelines` commands, if the extension isn't installed,
-    prompt interactively to install it -- which just hangs with no stdin attached.
+    prompt interactively to install it; which just hangs with no stdin attached.
     Checking via `az extension list` first (a core command that doesn't itself need
     the extension) avoids ever triggering that prompt.
 
@@ -150,7 +150,7 @@ def migrate(org: str, project: str, *, dry_run: bool) -> None:
     """Repoint each existing pipeline registration at its renamed name and yml-path.
 
     Whether a given entry even applies to this project is decided by whether its new
-    `.azurepipelines/*.yml` file exists on disk -- the ground truth for "this project
+    `.azurepipelines/*.yml` file exists on disk; the ground truth for "this project
     needs this pipeline," since that file only exists if the project's own answers
     caused copier to render it.
     """
@@ -185,7 +185,7 @@ def migrate(org: str, project: str, *, dry_run: bool) -> None:
 
         if old_id and new_id:
             print(
-                f"WARNING: both {old_full!r} and {new_full!r} are registered -- "
+                f"WARNING: both {old_full!r} and {new_full!r} are registered; "
                 "skipping, fix manually."
             )
         elif old_id:
@@ -211,7 +211,7 @@ def migrate(org: str, project: str, *, dry_run: bool) -> None:
         else:
             print(
                 f"WARNING: {yml_path} exists locally but no pipeline is registered "
-                f"under {old_full!r} or {new_full!r} -- create it manually, e.g. via "
+                f"under {old_full!r} or {new_full!r}; create it manually, e.g. via "
                 "'az pipelines create'."
             )
 
@@ -219,7 +219,7 @@ def migrate(org: str, project: str, *, dry_run: bool) -> None:
     if cruft:
         print(
             "\nPipelines registered for this repo that don't match any known old or "
-            "new name -- review manually, not auto-deleted:"
+            "new name; review manually, not auto-deleted:"
         )
         for name in cruft:
             print(f"  {name!r} (id {by_name[name]})")

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/release-auto-release.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/release-auto-release.yml
@@ -43,7 +43,7 @@ stages:
           - bash: mise install
             displayName: Run 'mise install'
           - bash: az extension add --name azure-devops
-            # Deliberately unpinned as of 2026-08 -- no Renovate-trackable version
+            # Deliberately unpinned as of 2026-08; no Renovate-trackable version
             # source could be found. Its GitHub releases are date-tagged (don't match
             # the real version number), and the matching-named PyPI package is an
             # unrelated SDK. The real version list lives in Azure/azure-cli-extensions'
@@ -57,7 +57,7 @@ stages:
           - bash: |
               # Commit-message sniffing isn't reliable here: AzDO's regular (non-squash)
               # merge commit message is "Merge pull request NNN from knope/release into
-              # main" -- it doesn't reproduce the PR title at all, unlike a squash merge.
+              # main"; it doesn't reproduce the PR title at all, unlike a squash merge.
               # Ask the API directly instead: is the most recently *completed* PR from
               # knope/release into main's merge commit the same commit that triggered
               # this run? That's true exactly once, for the run immediately after that

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/release-manual-createprerelease.yml
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/release-manual-createprerelease.yml
@@ -57,7 +57,7 @@ stages:
               $Tags = git tag --points-at HEAD
               $Duplicate = $Tags | Where-Object { $_ -match "-$([regex]::Escape($Label))\.\d+$" }
               if ($Duplicate) {
-                Write-Host "##vso[task.logissue type=error]This commit is already tagged as $Duplicate -- push a new commit before cutting another $Label prerelease."
+                Write-Host "##vso[task.logissue type=error]This commit is already tagged as $Duplicate; push a new commit before cutting another $Label prerelease."
                 throw "Duplicate prerelease"
               }
             displayName: Block Duplicate Prerelease
@@ -69,5 +69,5 @@ stages:
             displayName: Capture Version
           - pwsh: |
               $TagUrl = "$(System.CollectionUri)$(System.TeamProject)/_git/$(Build.Repository.Name)?version=GTv$(VERSION)"
-              Write-Host "##vso[task.logissue type=warning]Prerelease published: v$(VERSION) -- $TagUrl"
+              Write-Host "##vso[task.logissue type=warning]Prerelease published: v$(VERSION) ($TagUrl)"
             displayName: Emit Release Notice

--- a/template/{% if using_azdo %}.azurepipelines{% endif %}/test-auto-prvalidation.yml.jinja
+++ b/template/{% if using_azdo %}.azurepipelines{% endif %}/test-auto-prvalidation.yml.jinja
@@ -1,7 +1,7 @@
 name: $(BuildId)-pr_validation
 
 # Azure Repos Git doesn't support YAML `pr:` triggers at all (they only work for GitHub/
-# Bitbucket Cloud sources) -- this pipeline is triggered solely by the "PR Validation"
+# Bitbucket Cloud sources); this pipeline is triggered solely by the "PR Validation"
 # build-validation branch policy set up in copier.yml.jinja's repo-setup tasks, so there's
 # no `pr:` block here and no `autoCancel` (a `pr:`-trigger-only feature) to rely on.
 trigger:
@@ -89,7 +89,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           - bash: |
               # Scopes the lint run to files actually changed on this PR, matching
-              # GitHub's counterpart (which runs the same git diff) -- identical PR
+              # GitHub's counterpart (which runs the same git diff); identical PR
               # content could otherwise pass on GitHub and fail on Azure DevOps (or vice
               # versa) depending on unrelated pre-existing lint state elsewhere in the repo.
               git fetch origin $(System.PullRequest.TargetBranchName)

--- a/template/{% if using_github %}.github{% endif %}/settings.yml.jinja
+++ b/template/{% if using_github %}.github{% endif %}/settings.yml.jinja
@@ -1,4 +1,4 @@
-# Managed by the "Settings" GitHub App (https://github.com/apps/settings) -- do not
+# Managed by the "Settings" GitHub App (https://github.com/apps/settings); do not
 # edit repo settings in the GitHub UI, edit this file instead. Install the app with
 # access to this repo for changes here to take effect; see docs/prerequisites.md.
 
@@ -16,7 +16,7 @@ repository:
 
   # Free for public repos; needs a paid GitHub Advanced Security license on private
   # ones, so scoped to public only. New public repos under a personal account get
-  # this by default already, but org-owned ones don't -- this makes it explicit
+  # this by default already, but org-owned ones don't; this makes it explicit
   # either way rather than depending on that default.
   security_and_analysis:
     secret_scanning:
@@ -26,7 +26,7 @@ repository:
 {%- endif %}
 
 # The Settings App treats this list as authoritative: any label that exists on the
-# repo but isn't listed here gets deleted on sync -- including GitHub's own
+# repo but isn't listed here gets deleted on sync; including GitHub's own
 # auto-created defaults (bug, enhancement, etc.), which is why they're listed
 # explicitly below rather than left for GitHub to create on its own.
 labels:
@@ -77,7 +77,7 @@ rulesets:
     # actor_id 5 = the built-in "admin" repository role (undocumented by GitHub, but
     # widely confirmed: https://github.com/github/rest-api-description/issues/4406).
     # bypass_mode "pull_request" only lets an admin skip requirements when merging a
-    # PR (the "Merge without waiting for requirements" button) -- it doesn't grant a
+    # PR (the "Merge without waiting for requirements" button); it doesn't grant a
     # direct push past this ruleset the way "always" would.
     bypass_actors:
       - actor_type: RepositoryRole
@@ -102,7 +102,7 @@ rulesets:
           do_not_enforce_on_create: true
           # Matches the AzDO side's forced behavior (queue-on-source-update-only
           # false requires valid-duration 0, i.e. "recheck immediately when the
-          # target branch updates") -- keeps both platforms equally strict.
+          # target branch updates"); keeps both platforms equally strict.
           strict_required_status_checks_policy: true
           required_status_checks:
             # Job id from test-auto-prvalidation.yml.jinja's "tests" job (no `name:` set,

--- a/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-copierupdatecheck.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-copierupdatecheck.yml
@@ -49,7 +49,7 @@ jobs:
       actions: write
     steps:
       # Re-enables this workflow if GitHub disabled it for inactivity. Inlined from
-      # liskin/gh-workflow-keepalive, whose one step is pinned to `shell: sh` --
+      # liskin/gh-workflow-keepalive, whose one step is pinned to `shell: sh`,
       # unsupported on Windows runners, unlike bash, which is available there via Git
       # for Windows.
       - name: Re-enable Workflow

--- a/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-repohealthcheck.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/maint-auto-repohealthcheck.yml
@@ -47,12 +47,12 @@ jobs:
           APPRISE_URL: ${{ secrets.APPRISE_URL }}
         run: |
           # GitHub returns this response header only when the authenticating token
-          # (classic PATs, which is what REPO_MAINTENANCE_PAT must be -- see
+          # (classic PATs, which is what REPO_MAINTENANCE_PAT must be; see
           # docs/token-permissions.md) has an expiration date set; it's absent for a
           # token with no expiration, in which case there's nothing to warn about.
           expiration=$(gh api user -i | grep -i '^github-authentication-token-expiration:' | cut -d: -f2- | xargs)
           if [ -z "$expiration" ]; then
-            echo "REPO_MAINTENANCE_PAT has no expiration set -- nothing to warn about."
+            echo "REPO_MAINTENANCE_PAT has no expiration set; nothing to warn about."
             exit 0
           fi
           days_left=$(( ($(date -d "$expiration" +%s) - $(date +%s)) / 86400 ))
@@ -71,7 +71,7 @@ jobs:
       actions: write
     steps:
       # Re-enables this workflow if GitHub disabled it for inactivity. Inlined from
-      # liskin/gh-workflow-keepalive, whose one step is pinned to `shell: sh` --
+      # liskin/gh-workflow-keepalive, whose one step is pinned to `shell: sh`,
       # unsupported on Windows runners, unlike bash, which is available there via Git
       # for Windows.
       - name: Re-enable Workflow

--- a/template/{% if using_github %}.github{% endif %}/workflows/release-auto-preparereleasepr.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/release-auto-preparereleasepr.yml
@@ -17,12 +17,12 @@ jobs:
         # token: a PAT, not the default GITHUB_TOKEN. Since June 2026, GitHub gates
         # pull_request-triggered runs (e.g. PR Validation on the release PR below)
         # behind manual approval whenever the PR traces back to the default token's
-        # github-actions[bot] identity -- see
+        # github-actions[bot] identity; see
         # https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/,
         # whose documented workaround is a trusted identity (PAT or GitHub App)
         # instead of GITHUB_TOKEN. Confirmed live across 4 configurations: both this
         # token and the "Prepare Release PR" step's own GITHUB_TOKEN below must be the
-        # PAT for the run to go through clean -- defaulting either one alone (checkout
+        # PAT for the run to go through clean; defaulting either one alone (checkout
         # only, or the knope step only) still gets gated, even though the other
         # already has the PAT. It's not about git CLI vs API-based tooling; every
         # credential touching this branch and PR needs to be the PAT.

--- a/template/{% if using_github %}.github{% endif %}/workflows/release-auto-publishrelease.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/release-auto-publishrelease.yml
@@ -28,7 +28,7 @@ jobs:
         run: mise x -- knope release-on-knope-pr-merge --verbose
         env:
           # A release created with the default GITHUB_TOKEN doesn't fire a `release:
-          # published` event that other workflows can react to -- GitHub explicitly
+          # published` event that other workflows can react to; GitHub explicitly
           # doesn't cascade-trigger workflows from GITHUB_TOKEN-authenticated actions,
           # to prevent recursive runs. docs-auto-zensical.yml's `on: release:
           # published` listener (which publishes the "latest" Pages docs alias) would

--- a/template/{% if using_github %}.github{% endif %}/workflows/release-manual-createprerelease.yml
+++ b/template/{% if using_github %}.github{% endif %}/workflows/release-manual-createprerelease.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           duplicate=$(git tag --points-at HEAD | grep -E -- "-${LABEL}\.[0-9]+$" || true)
           if [ -n "$duplicate" ]; then
-            echo "::error::This commit is already tagged as $duplicate -- push a new commit before cutting another $LABEL prerelease."
+            echo "::error::This commit is already tagged as $duplicate; push a new commit before cutting another $LABEL prerelease."
             exit 1
           fi
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4

--- a/template/{% if using_github %}.github{% endif %}/workflows/test-auto-prvalidation.yml.jinja
+++ b/template/{% if using_github %}.github{% endif %}/workflows/test-auto-prvalidation.yml.jinja
@@ -2,7 +2,7 @@ name: "Test (Auto): PR Validation"
 
 on:
   pull_request:
-    # Explicit -- the implicit default (opened, synchronize, reopened) omits `edited`,
+    # Explicit; the implicit default (opened, synchronize, reopened) omits `edited`,
     # so a title-only edit wouldn't otherwise re-run the PR-title check below.
     types: [opened, edited, synchronize, reopened]
 

--- a/template/{% if using_github %}.github{% endif %}/workflows/{% if zensical_ghpages %}docs-auto-zensical.yml{% endif %}
+++ b/template/{% if using_github %}.github{% endif %}/workflows/{% if zensical_ghpages %}docs-auto-zensical.yml{% endif %}
@@ -38,7 +38,7 @@ jobs:
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
         with:
           # mike is a git dependency, so uv builds it from source using a python
-          # interpreter under the runner's ephemeral _temp dir -- a path that's never
+          # interpreter under the runner's ephemeral _temp dir; a path that's never
           # part of this cache. A cached mike from a different job's run references an
           # interpreter path that no longer exists, failing with "cannot execute:
           # required file not found". This is the only workflow that actually invokes
@@ -54,7 +54,7 @@ jobs:
             zensical-
       - name: Check for gh-pages Index
         id: index-check
-        # jiangxin/file-exists-action is unmaintained (GitHub flags it) -- this is
+        # jiangxin/file-exists-action is unmaintained (GitHub flags it); this is
         # simple enough to inline. fetch-depth: 0 above fetches all branches, so
         # origin/gh-pages is resolvable locally without a separate checkout.
         shell: bash


### PR DESCRIPTION
Repo-wide pass removing double-hyphen ("--") used as prose punctuation across template/, replacing it with a colon, semicolon, or parenthetical depending on what each sentence actually needs. Genuine shell syntax (mise x -- <tool>, git ... -- <path>) is left untouched.

Root copier.yml and renovate.json re-synced to match the corresponding template/ edits.