### PR TITLE
docs: convert platform sections to tabs, close survey gaps

### DIFF
--- a/template/zensical.toml.jinja
+++ b/template/zensical.toml.jinja
@@ -1,5 +1,6 @@
 [project]
 site_name = "{{ project_name }}"
+site_description = "{{ project_description }}"
 docs_dir = "docs"
 site_dir = "{% if zensical_ghpages %}.cache/zensical_serve{% else %}docs-site{% endif %}"
 {%- if is_template %}
@@ -47,7 +48,9 @@ alias = true
 variant = "classic" # Switching to modern blocked until built-in versioning support is added
 custom_dir = ".config/zensical-overrides"
 features = [
+  "content.code.annotate",
   "content.code.copy",
+  "content.tabs.link",
   "navigation.indexes",
   "navigation.footer",
   "navigation.path",
@@ -55,6 +58,8 @@ features = [
   "navigation.top",
   "navigation.tracking",
   "search.highlight",
+  "search.share",
+  "search.suggest",
   "toc.follow",
 ]
 font.text = "Lato"

--- a/template/{% if is_template %}docs{% endif %}/manual-repo-settings.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/manual-repo-settings.md.jinja
@@ -1,93 +1,93 @@
 # Manual Repo Settings
 
-## GitHub
+=== "GitHub"
 
-When you use the [Settings GitHub App](https://github.com/apps/settings), it syncs the repo
-settings, labels, and branch protection ruleset described below from the committed
-`.github/settings.yml` automatically. If you don't want to install that app (or can't, e.g. it's
-not been approved for your organization), here's how to apply the same configuration by hand
-through the GitHub UI. `.github/settings.yml` is the source of truth for the exact values below;
-if the two ever disagree, trust the file.
+    When you use the [Settings GitHub App](https://github.com/apps/settings), it syncs the repo
+    settings, labels, and branch protection ruleset described below from the committed
+    `.github/settings.yml` automatically. If you don't want to install that app (or can't, e.g. it's
+    not been approved for your organization), here's how to apply the same configuration by hand
+    through the GitHub UI. `.github/settings.yml` is the source of truth for the exact values below;
+    if the two ever disagree, trust the file.
 
-### Labels
+    ### Labels
 
-Under the repo's **Issues** tab, open **Labels**, and create:
+    Under the repo's **Issues** tab, open **Labels**, and create:
 
-| Name | Color | Description |
-| --- | --- | --- |
-| `awaiting pr` | `#668F04` | Awaiting completion of a PR from a contributor |
-| `blocked` | `#B60205` | Blocked by an external dependency |
+    | Name | Color | Description |
+    | --- | --- | --- |
+    | `awaiting pr` | `#668F04` | Awaiting completion of a PR from a contributor |
+    | `blocked` | `#B60205` | Blocked by an external dependency |
 
-### Merge Options
+    ### Merge Options
 
-Under **Settings > General > Pull Requests**, enable:
+    Under **Settings > General > Pull Requests**, enable:
 
-- **Allow auto-merge**
-- **Automatically delete head branches**
+    - **Allow auto-merge**
+    - **Automatically delete head branches**
 
-### Branch Protection
+    ### Branch Protection
 
-Under **Settings > Rules > Rulesets**, create a new ruleset:
+    Under **Settings > Rules > Rulesets**, create a new ruleset:
 
-- Name: `default-branch-protection`
-- Enforcement status: **Active**
-- Target branches: **Default branch**
-- Rules:
-    - **Restrict deletions**
-    - **Block force pushes**
-    - **Require a pull request before merging**, with:
-        - Required approvals: `0`
-        - Dismiss stale pull request approvals when new commits are pushed: off
-        - Require review from Code Owners: off
-        - Require approval of the most recent reviewable push: off
-        - Require conversation resolution before merging: off
-    - **Require status checks to pass**, with:
-        - Require branches to be up to date before merging: on
-        - Status check: `tests` (the job in `Test (Auto): PR Validation`)
-- Bypass list: add **Repository admin**, with bypass mode **Pull requests only**; this lets
-  repo admins use the "Merge without waiting for requirements to be met" button instead of being
-  blocked entirely.
+    - Name: `default-branch-protection`
+    - Enforcement status: **Active**
+    - Target branches: **Default branch**
+    - Rules:
+        - **Restrict deletions**
+        - **Block force pushes**
+        - **Require a pull request before merging**, with:
+            - Required approvals: `0`
+            - Dismiss stale pull request approvals when new commits are pushed: off
+            - Require review from Code Owners: off
+            - Require approval of the most recent reviewable push: off
+            - Require conversation resolution before merging: off
+        - **Require status checks to pass**, with:
+            - Require branches to be up to date before merging: on
+            - Status check: `tests` (the job in `Test (Auto): PR Validation`)
+    - Bypass list: add **Repository admin**, with bypass mode **Pull requests only**; this lets
+      repo admins use the "Merge without waiting for requirements to be met" button instead of being
+      blocked entirely.
 
-### GitHub Pages Environment
+    ### GitHub Pages Environment
 
-(`zensical_target: GitHub Pages` only.)
+    (`zensical_target: GitHub Pages` only.)
 
-After the first successful Pages deployment, an environment named `github-pages` will exist under
-**Settings > Environments**. Open it and ensure **Deployment branches and tags** is set to
-**All branches** (no restriction).
+    After the first successful Pages deployment, an environment named `github-pages` will exist under
+    **Settings > Environments**. Open it and ensure **Deployment branches and tags** is set to
+    **All branches** (no restriction).
 
-### Security and Analysis
+    ### Security and Analysis
 
-(Public repos only; private repos need a paid GitHub Advanced Security license.)
+    (Public repos only; private repos need a paid GitHub Advanced Security license.)
 
-Under **Settings > Code security**, enable **Secret scanning** and **Push protection**.
+    Under **Settings > Code security**, enable **Secret scanning** and **Push protection**.
 
-## Azure DevOps
+=== "Azure DevOps"
 
-If you chose `repo_setup_actions: None` (or need to reapply this after the fact), here's how to
-recreate what `Create Repo`/`Set Repo Rules` would otherwise set up automatically, through the
-Azure DevOps UI.
+    If you chose `repo_setup_actions: None` (or need to reapply this after the fact), here's how to
+    recreate what `Create Repo`/`Set Repo Rules` would otherwise set up automatically, through the
+    Azure DevOps UI.
 
-### Pipelines
+    ### Pipelines
 
-Under **Pipelines > New pipeline**, create one pipeline per file under `.azurepipelines/`,
-pointing each at the matching YAML file in this repo. Name each
-`[{{ repo_name }}] <Category> (<Auto|Manual>) - <Name>`
-(e.g. `[{{ repo_name }}] Test (Auto) - PR Validation`) to match what this template's own automation
-would have named them.
+    Under **Pipelines > New pipeline**, create one pipeline per file under `.azurepipelines/`,
+    pointing each at the matching YAML file in this repo. Name each
+    `[{{ repo_name }}] <Category> (<Auto|Manual>) - <Name>`
+    (e.g. `[{{ repo_name }}] Test (Auto) - PR Validation`) to match what this template's own automation
+    would have named them.
 
-### PR-Validation Branch Policy
+    ### PR-Validation Branch Policy
 
-Under **Project Settings > Repositories > (this repo) > Policies > Branch Policies > main**, add
-a **Build Validation** policy:
+    Under **Project Settings > Repositories > (this repo) > Policies > Branch Policies > main**, add
+    a **Build Validation** policy:
 
-- Build pipeline: the `Test (Auto) - PR Validation` pipeline created above
-- Trigger: **Automatic**
-- Policy requirement: **Required**
-- Build expiration: **Immediately**
+    - Build pipeline: the `Test (Auto) - PR Validation` pipeline created above
+    - Trigger: **Automatic**
+    - Policy requirement: **Required**
+    - Build expiration: **Immediately**
 
-### Bypass Permission
+    ### Bypass Permission
 
-Under **Project Settings > Repositories > (this repo) > Security**, select **Project
-Administrators** and set **Bypass policies when completing pull requests** to **Allow**; this
-lets project admins use the "Complete" button's bypass option instead of being blocked entirely.
+    Under **Project Settings > Repositories > (this repo) > Security**, select **Project
+    Administrators** and set **Bypass policies when completing pull requests** to **Allow**; this
+    lets project admins use the "Complete" button's bypass option instead of being blocked entirely.

--- a/template/{% if is_template %}docs{% endif %}/prerequisites.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/prerequisites.md.jinja
@@ -1,67 +1,67 @@
 # Prerequisites
 
-## Azure DevOps
+=== "GitHub"
 
-### One-Time Actions Per Azure DevOps Organization
+    ### One-Time Actions Per GitHub User/Organization
 
-1. Install the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) (`az`) via an
-    officially supported method (winget/MSI on Windows, Homebrew on macOS, apt/dnf/zypper on Linux,
-    since installing via pip/pipx is not supported by Microsoft), then run
-    `az extension add --name azure-devops` and `az login`. Unless you choose `None` for the
-    `repo_setup_actions` question, this is used instead of a Personal Access Token to create your
-    repo and register its pipelines. The `repo_setup_actions` question's validator checks that
-    `az`, the `azure-devops` extension, and login are all in place before letting you proceed.
-1. Make sure [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager) is
-    installed (bundled with Git for Windows if you enabled it during install; a separate install on
-    macOS/Linux). The initial `git push` isn't covered by `az login` (see
-    [Token Permissions](token-permissions.md#az-login-permissions) for why), so GCM handles that
-    push's authentication with its own (separate) interactive Entra sign-in the first time.
+    1. Install the [GitHub CLI](https://cli.github.com) (`gh`) and run `gh auth login` (default
+        scopes are enough). Unless you choose `None` for the `repo_setup_actions` question, this is
+        used instead of a Personal Access Token to create/configure your repo. The `repo_setup_actions`
+        question's validator checks that `gh` is installed and authenticated before letting you
+        proceed.
+    1. Make sure [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager) is
+        installed (bundled with Git for Windows if you enabled it during install; a separate install on
+        macOS/Linux). `gh auth login`'s default scopes don't cover pushing `.github/workflows/` files
+        (see [Token Permissions](token-permissions.md#gh-auth-login-scopes) for why), so GCM handles the
+        initial push with its own (separate) interactive GitHub sign-in the first time.
+    1. Install the [AllContributors GitHub App](https://github.com/apps/allcontributors/installations/new) for your user or organization.
+        - This app provides automatic README crediting when other people contribute to your project
+        - If you know you are only going to be making Private projects, you can skip installing this app
+        - It is recommended that you give it access to all your repositories, which means you only need to do this step once rather than for each new repo.
+    1. Install the [Renovate GitHub App](https://github.com/apps/renovate) for your user or organization.
+        - This app provides automatic dependency updates for your project
+        - It is recommended that you give it access to all your repositories, which means you only need to do this step once rather than for each new repo.
+    1. Install the [Settings GitHub App](https://github.com/apps/settings) for your user or organization.
+        - This app syncs repo settings (labels, merge options, branch protection) from the committed `.github/settings.yml`, which is always generated for GitHub projects
+        - It must have access to a repo *before* that repo is created for its settings to apply, so grant it access to all your repositories up front, same as the apps above
+        - Skipping this is fine; see [Manual Repo Settings](manual-repo-settings.md) for how to apply the same configuration by hand instead
+    1. Install the [Codecov GitHub App](https://github.com/apps/codecov) for your user or organization.
+        - This app powers Codecov's PR comments/checks and connects your repo to codecov.io for uploads
+        - Only needed if you plan to answer Yes to the `code_coverage` question; skip this if you don't want code coverage reporting
+        - It is recommended that you give it access to all your repositories, which means you only need to do this step once rather than for each new repo.
 
-### One-Time Actions per Azure DevOps Project
+=== "Azure DevOps"
 
-In order to support the proper parsing of Conventional Commits, the following must be set:
+    ### One-Time Actions Per Azure DevOps Organization
 
-- `Project settings`
-    - `Repositories`
-        - `Settings` tab
-            - `All Repositories Settings` section
-                - Ensure `Include PR ID in the completion commit message title by default` is set to `Off`
-        - `Security` tab
-            - `PROJECTNAME Build Service (PROJECTNAME)`
-                - Set these to `Allow`:
-                    - Contribute
-                    - Contribute to pull requests
-                    - Create branch
+    1. Install the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) (`az`) via an
+        officially supported method (winget/MSI on Windows, Homebrew on macOS, apt/dnf/zypper on Linux,
+        since installing via pip/pipx is not supported by Microsoft), then run
+        `az extension add --name azure-devops` and `az login`. Unless you choose `None` for the
+        `repo_setup_actions` question, this is used instead of a Personal Access Token to create your
+        repo and register its pipelines. The `repo_setup_actions` question's validator checks that
+        `az`, the `azure-devops` extension, and login are all in place before letting you proceed.
+    1. Make sure [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager) is
+        installed (bundled with Git for Windows if you enabled it during install; a separate install on
+        macOS/Linux). The initial `git push` isn't covered by `az login` (see
+        [Token Permissions](token-permissions.md#az-login-permissions) for why), so GCM handles that
+        push's authentication with its own (separate) interactive Entra sign-in the first time.
 
-## GitHub
+    ### One-Time Actions per Azure DevOps Project
 
-### One-Time Actions Per GitHub User/Organization
+    In order to support the proper parsing of Conventional Commits, the following must be set:
 
-1. Install the [GitHub CLI](https://cli.github.com) (`gh`) and run `gh auth login` (default
-    scopes are enough). Unless you choose `None` for the `repo_setup_actions` question, this is
-    used instead of a Personal Access Token to create/configure your repo. The `repo_setup_actions`
-    question's validator checks that `gh` is installed and authenticated before letting you
-    proceed.
-1. Make sure [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager) is
-    installed (bundled with Git for Windows if you enabled it during install; a separate install on
-    macOS/Linux). `gh auth login`'s default scopes don't cover pushing `.github/workflows/` files
-    (see [Token Permissions](token-permissions.md#gh-auth-login-scopes) for why), so GCM handles the
-    initial push with its own (separate) interactive GitHub sign-in the first time.
-1. Install the [AllContributors GitHub App](https://github.com/apps/allcontributors/installations/new) for your user or organization.
-    - This app provides automatic README crediting when other people contribute to your project
-    - If you know you are only going to be making Private projects, you can skip installing this app
-    - It is recommended that you give it access to all your repositories, which means you only need to do this step once rather than for each new repo.
-1. Install the [Renovate GitHub App](https://github.com/apps/renovate) for your user or organization.
-    - This app provides automatic dependency updates for your project
-    - It is recommended that you give it access to all your repositories, which means you only need to do this step once rather than for each new repo.
-1. Install the [Settings GitHub App](https://github.com/apps/settings) for your user or organization.
-    - This app syncs repo settings (labels, merge options, branch protection) from the committed `.github/settings.yml`, which is always generated for GitHub projects
-    - It must have access to a repo *before* that repo is created for its settings to apply, so grant it access to all your repositories up front, same as the apps above
-    - Skipping this is fine; see [Manual Repo Settings](manual-repo-settings.md) for how to apply the same configuration by hand instead
-1. Install the [Codecov GitHub App](https://github.com/apps/codecov) for your user or organization.
-    - This app powers Codecov's PR comments/checks and connects your repo to codecov.io for uploads
-    - Only needed if you plan to answer Yes to the `code_coverage` question; skip this if you don't want code coverage reporting
-    - It is recommended that you give it access to all your repositories, which means you only need to do this step once rather than for each new repo.
+    - `Project settings`
+        - `Repositories`
+            - `Settings` tab
+                - `All Repositories Settings` section
+                    - Ensure `Include PR ID in the completion commit message title by default` is set to `Off`
+            - `Security` tab
+                - `PROJECTNAME Build Service (PROJECTNAME)`
+                    - Set these to `Allow`:
+                        - Contribute
+                        - Contribute to pull requests
+                        - Create branch
 
 ## Personal Access Tokens
 

--- a/template/{% if is_template %}docs{% endif %}/public-vs-private-repos.md
+++ b/template/{% if is_template %}docs{% endif %}/public-vs-private-repos.md
@@ -27,3 +27,14 @@ Private repos omit the following features that would not be relevant to them, wi
     - Likely not needed for a private project, but you can always provide your own custom file which will be ignored by template updates
 - `LICENSE`
     - No need to license something not available to others, but you can always provide your own custom file which will be ignored by template updates
+
+### Security Scanning (GitHub)
+
+Private repos omit these because they require a paid GitHub Advanced Security license there;
+they're free and automatic on Public repos.
+
+- CodeQL code scanning's default setup
+- Private vulnerability reporting, so a security issue can be reported confidentially instead of
+  only via a public issue
+- Secret scanning and push protection; see [Manual Repo Settings](manual-repo-settings.md) if you
+  need to enable these by hand

--- a/template/{% if is_template %}docs{% endif %}/token-permissions.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/token-permissions.md.jinja
@@ -19,40 +19,43 @@ validation failing to pass. Unlike the tokens below, it isn't a scope to grant; 
 notifications sent (email, Slack, Discord, ntfy, Pushover, and 80+ others; see Apprise's own
 docs for the URL format for your service of choice).
 
-## GitHub
+=== "GitHub"
 
-### `gh auth login` Scopes
+    ### `gh auth login` Scopes
 
-Repo creation and configuration (labels, merge options, branch protection, Actions permissions,
-Pages) uses the [GitHub CLI](https://cli.github.com)'s own authenticated session rather than a
-prompted Personal Access Token; see [Prerequisites](prerequisites.md). Default scopes (`repo`
-among them) are enough; no need for `gh auth login --scopes ...`. The initial `git push` is a
-separate matter; `gh auth login`'s scopes don't cover pushing `.github/workflows/` files
-regardless, so that step uses Git Credential Manager's own login instead, not `gh`'s.
+    Repo creation and configuration (labels, merge options, branch protection, Actions permissions,
+    Pages) uses the [GitHub CLI](https://cli.github.com)'s own authenticated session rather than a
+    prompted Personal Access Token; see [Prerequisites](prerequisites.md). Default scopes (`repo`
+    among them) are enough; no need for `gh auth login --scopes ...`. The initial `git push` is a
+    separate matter; `gh auth login`'s scopes don't cover pushing `.github/workflows/` files
+    regardless, so that step uses Git Credential Manager's own login instead, not `gh`'s.
 
-### Repo Maintenance PAT (Classic Token)
+    ### Repo Maintenance PAT (Classic Token)
 
-For best security, create this token via [this link](https://github.com/settings/personal-access-tokens/new)
-and save it as a GitHub Actions secret on the repository called **REPO_MAINTENANCE_PAT**. This is
-separate from `gh auth login` above; it's used on an ongoing basis by this project's own GitHub
-Actions workflows (Copier update checks, docs builds), not just at setup time.
+    For best security, create this token via [this link](https://github.com/settings/personal-access-tokens/new)
+    and save it as a GitHub Actions secret on the repository called **REPO_MAINTENANCE_PAT**. This is
+    separate from `gh auth login` above; it's used on an ongoing basis by this project's own GitHub
+    Actions workflows (Copier update checks, docs builds), not just at setup time.
 
-**Repository Access**: All repositories
+    **Repository Access**: All repositories
 
-| **Scope**                     | **Reason**                        |
-| ----------------------------- | ---------------------------------- |
-| repo                          | Needed for Copier/docs workflows   |
+    | **Scope** | **Reason**                        |
+    | --------- | ---------------------------------- |
+    | `repo`    | Needed for Copier/docs workflows   |
 
-NOTE: Fine-grained tokens are specifically **not** used, as they cannot open pull requests. This can be changed once [this issue](https://github.com/github/roadmap/issues/600) is implemented by GitHub.
+    !!! note
+        Fine-grained tokens are specifically **not** used, since they cannot open pull requests.
+        This can be changed once [this issue](https://github.com/github/roadmap/issues/600) is
+        implemented by GitHub.
 
-## Azure DevOps
+=== "Azure DevOps"
 
-### `az login` Permissions
+    ### `az login` Permissions
 
-Repo creation and pipeline registration use the
-[Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)'s own authenticated session
-(see [Prerequisites](prerequisites.md)). No PAT scopes to configure; the signed-in account just needs
-enough permission in the target project to create repos and pipelines (typically **Project
-Administrator**, or an equivalent custom permission set covering `Code: Full` and
-`Build: Read & Execute`). The initial `git push` is a separate matter; `az login` doesn't bridge
-into git's credentials, so that step uses Git Credential Manager's own login instead.
+    Repo creation and pipeline registration use the
+    [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)'s own authenticated session
+    (see [Prerequisites](prerequisites.md)). No PAT scopes to configure; the signed-in account just
+    needs enough permission in the target project to create repos and pipelines (typically
+    **Project Administrator**, or an equivalent custom permission set covering `Code: Full` and
+    `Build: Read & Execute`). The initial `git push` is a separate matter; `az login` doesn't bridge
+    into git's credentials, so that step uses Git Credential Manager's own login instead.


### PR DESCRIPTION
Converts the three docs pages structured as a "## GitHub" section followed by a "## Azure DevOps" section (Prerequisites, Token Permissions, Manual Repo Settings) into content tabs, matching the pattern extending-the-template.md already established and cutting scroll distance for anyone who only cares about one platform. Prerequisites is also reordered GitHub-first to match the other two.

Fixes a literal "NOTE:" in Token Permissions to use the real !!! note admonition the theme already supports, and tightens its scope table's column alignment.

Adds a Security Scanning section to Public vs Private Repos: CodeQL, private vulnerability reporting, and secret scanning/push protection were never mentioned there even though they're gated on the same public/private axis as everything else on that page.

zensical.toml.jinja: adds site_description (SEO/social meta, sourced from the existing project_description answer) and four theme features that were available but unused: content.code.annotate, content.tabs.link, search.suggest, search.share.