### PR TITLE
docs: document upstream-update changesets in the releasing guide

### DIFF
--- a/template/{% if is_standard %}docs{% endif %}/releasing.md.jinja
+++ b/template/{% if is_standard %}docs{% endif %}/releasing.md.jinja
@@ -9,27 +9,38 @@ Commits](https://www.conventionalcommits.org/).
 ## Normal Releases
 
 Every push to `main` opens or updates a pull request (branch `knope/release`)
-proposing the next release, computed from commit messages since the last release --
+proposing the next release, computed from commit messages since the last release:
 `fix:` bumps the patch version, `feat:` bumps minor, and a `!`/`BREAKING CHANGE:`
 commit bumps major. Merging that PR tags and publishes the release automatically.
 
 If a push has nothing release-worthy in it (e.g. a `docs:`- or `chore:`-only commit),
-the workflow run shows a failed step but stays green overall -- that's expected, not a
+the workflow run shows a failed step but stays green overall; that's expected, not a
 bug, and no PR is opened or updated.
+
+## Upstream Template Update Changesets
+
+A `copier update` that pulls in template changes may drop one or more files into
+`.changeset/`, one per relevant upstream change. No action is required beyond a quick
+review: Knope folds each one into your very next release the same way it folds in your
+own commits, combining bump types (major beats minor beats patch) and filing each entry
+under the matching changelog section. Delete any that don't actually apply to your
+project (a fix for the other platform, template-internal tooling) before that release
+runs. Each entry links back to the PR it actually came from upstream, not this project,
+so you can always check the source before deciding.
 
 ## Prereleases
 
 To cut an ad-hoc prerelease (`alpha`, `beta`, or `rc`), run the "Release (Manual): Create
 Prerelease" workflow from the Actions tab, choosing a label. Each dispatch increments
 that label's number (e.g. `1.1.0-alpha.0`, then `.1`). Cutting the same label again at
-the same commit is blocked -- push a new commit first -- but moving to a new label
+the same commit is blocked (push a new commit first), but moving to a new label
 (e.g. `alpha` to `beta`) is always allowed, even without one.
 
 ## Graduating to 1.0.0
 
 While your project's lifecycle is Pre-Alpha, Alpha, or Beta, normal commits only ever
-bump the minor/patch version -- Knope won't cross the `1.0.0` line on its own. Once
-you're ready, run `mise run set-lifecycle` and choose `Stable` -- you'll get a message
+bump the minor/patch version; Knope won't cross the `1.0.0` line on its own. Once
+you're ready, run `mise run set-lifecycle` and choose `Stable`; you'll get a message
 with a ready-to-run command that opens a pull request proposing the `1.0.0` release.
 Merging that PR publishes it.
 {%- elif using_azdo %}
@@ -41,26 +52,37 @@ Commits](https://www.conventionalcommits.org/).
 ## Normal Releases
 
 Every push to `main` opens or updates a pull request (branch `knope/release`)
-proposing the next release, computed from commit messages since the last release --
+proposing the next release, computed from commit messages since the last release:
 `fix:` bumps the patch version, `feat:` bumps minor, and a `!`/`BREAKING CHANGE:`
 commit bumps major. Merging that PR tags and publishes the release automatically.
 
 If a push has nothing release-worthy in it (e.g. a `docs:`- or `chore:`-only commit),
-the pipeline run shows a failed step but stays green overall -- that's expected, not a
+the pipeline run shows a failed step but stays green overall; that's expected, not a
 bug, and no PR is opened or updated.
+
+## Upstream Template Update Changesets
+
+A `copier update` that pulls in template changes may drop one or more files into
+`.changeset/`, one per relevant upstream change. No action is required beyond a quick
+review: Knope folds each one into your very next release the same way it folds in your
+own commits, combining bump types (major beats minor beats patch) and filing each entry
+under the matching changelog section. Delete any that don't actually apply to your
+project (a fix for the other platform, template-internal tooling) before that release
+runs. Each entry links back to the repo it actually came from upstream, not this
+project, so you can always check the source before deciding.
 
 ## Prereleases
 
 To cut an ad-hoc prerelease (`alpha`, `beta`, or `rc`), run the "Release (Manual) - Create
 Prerelease" pipeline manually from Azure Pipelines, choosing a label. Each dispatch increments that label's
 number (e.g. `1.1.0-alpha.0`, then `.1`). Cutting the same label again at the same
-commit is blocked -- push a new commit first -- but moving to a new label (e.g. `alpha`
+commit is blocked (push a new commit first), but moving to a new label (e.g. `alpha`
 to `beta`) is always allowed, even without one.
 
 ## Graduating to 1.0.0
 
 While your project's lifecycle is Pre-Alpha, Alpha, or Beta, normal commits only ever
-bump the minor/patch version -- Knope won't cross the `1.0.0` line on its own. Once
+bump the minor/patch version; Knope won't cross the `1.0.0` line on its own. Once
 you're ready, run `knope autoupdate-knope-pr --override-version 1.0.0` to open a pull
 request proposing that release. Merging that PR publishes it.
 {%- endif %}

--- a/template/{% if is_template %}docs{% endif %}/releasing.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/releasing.md.jinja
@@ -9,26 +9,37 @@ Commits](https://www.conventionalcommits.org/).
 ## Normal Releases
 
 Every push to `main` opens or updates a pull request (branch `knope/release`)
-proposing the next release, computed from commit messages since the last release --
+proposing the next release, computed from commit messages since the last release:
 `fix:` bumps the patch version, `feat:` bumps minor, and a `!`/`BREAKING CHANGE:`
 commit bumps major. Merging that PR tags and publishes the release automatically.
 
 If a push has nothing release-worthy in it (e.g. a `docs:`- or `chore:`-only commit),
-the workflow run shows a failed step but stays green overall -- that's expected, not a
+the workflow run shows a failed step but stays green overall; that's expected, not a
 bug, and no PR is opened or updated.
+
+## Upstream Template Update Changesets
+
+A `copier update` that pulls in template changes may drop one or more files into
+`.changeset/`, one per relevant upstream change. No action is required beyond a quick
+review: Knope folds each one into your very next release the same way it folds in your
+own commits, combining bump types (major beats minor beats patch) and filing each entry
+under the matching changelog section. Delete any that don't actually apply to your
+project (a fix for the other platform, template-internal tooling) before that release
+runs. Each entry links back to the PR it actually came from upstream, not this project,
+so you can always check the source before deciding.
 
 ## Prereleases
 
 To cut an ad-hoc prerelease (`alpha`, `beta`, or `rc`), run the "Release (Manual): Create
 Prerelease" workflow from the Actions tab, choosing a label. Each dispatch increments
 that label's number (e.g. `1.1.0-alpha.0`, then `.1`). Cutting the same label again at
-the same commit is blocked -- push a new commit first -- but moving to a new label
+the same commit is blocked (push a new commit first), but moving to a new label
 (e.g. `alpha` to `beta`) is always allowed, even without one.
 
 ## Graduating to 1.0.0
 
 While your project's lifecycle is Pre-Alpha, Alpha, or Beta, normal commits only ever
-bump the minor/patch version -- Knope won't cross the `1.0.0` line on its own. See
+bump the minor/patch version; Knope won't cross the `1.0.0` line on its own. See
 [Lifecycle Management](lifecycle-management.md) for how to trigger that release when
 you're ready.
 {%- elif using_azdo %}
@@ -40,26 +51,37 @@ Commits](https://www.conventionalcommits.org/).
 ## Normal Releases
 
 Every push to `main` opens or updates a pull request (branch `knope/release`)
-proposing the next release, computed from commit messages since the last release --
+proposing the next release, computed from commit messages since the last release:
 `fix:` bumps the patch version, `feat:` bumps minor, and a `!`/`BREAKING CHANGE:`
 commit bumps major. Merging that PR tags and publishes the release automatically.
 
 If a push has nothing release-worthy in it (e.g. a `docs:`- or `chore:`-only commit),
-the pipeline run shows a failed step but stays green overall -- that's expected, not a
+the pipeline run shows a failed step but stays green overall; that's expected, not a
 bug, and no PR is opened or updated.
+
+## Upstream Template Update Changesets
+
+A `copier update` that pulls in template changes may drop one or more files into
+`.changeset/`, one per relevant upstream change. No action is required beyond a quick
+review: Knope folds each one into your very next release the same way it folds in your
+own commits, combining bump types (major beats minor beats patch) and filing each entry
+under the matching changelog section. Delete any that don't actually apply to your
+project (a fix for the other platform, template-internal tooling) before that release
+runs. Each entry links back to the repo it actually came from upstream, not this
+project, so you can always check the source before deciding.
 
 ## Prereleases
 
 To cut an ad-hoc prerelease (`alpha`, `beta`, or `rc`), run the "Release (Manual) - Create
 Prerelease" pipeline manually from Azure Pipelines, choosing a label. Each dispatch increments that label's
 number (e.g. `1.1.0-alpha.0`, then `.1`). Cutting the same label again at the same
-commit is blocked -- push a new commit first -- but moving to a new label (e.g. `alpha`
+commit is blocked (push a new commit first), but moving to a new label (e.g. `alpha`
 to `beta`) is always allowed, even without one.
 
 ## Graduating to 1.0.0
 
 While your project's lifecycle is Pre-Alpha, Alpha, or Beta, normal commits only ever
-bump the minor/patch version -- Knope won't cross the `1.0.0` line on its own. See
+bump the minor/patch version; Knope won't cross the `1.0.0` line on its own. See
 [Lifecycle Management](lifecycle-management.md) for how to trigger that release when
 you're ready.
 {%- endif %}


### PR DESCRIPTION
The .changeset/ mechanism (files a `copier update` can drop in, one per relevant upstream change) had no reader-facing documentation at all. Adds an "Upstream Template Update Changesets" section explaining what they are, that Knope folds them into the next release automatically, and that entries not relevant to this project should just be deleted before that release runs.