### PR TITLE
docs: add a real introduction and fix missed em dashes

### DIFF
--- a/template/{% if is_template %}docs{% endif %}/index.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/index.md.jinja
@@ -1,5 +1,44 @@
 # Getting Started
 
+{{ project_name }} is a [Copier](https://copier.readthedocs.io/) template: running it against a
+destination path generates a ready-to-use repository with the "hard/boring stuff" (CI/CD,
+linting, releasing, documentation, repo settings) already wired up, so whoever uses it can get
+straight to building whatever the project is actually for.
+
+## The Two Decisions That Shape Everything
+
+Every question this template asks branches off two choices, made once at the very start and
+locked in from then on:
+
+- **`developer_platform`** (GitHub or Azure DevOps): which CI/CD system, secrets store, and repo
+  host the generated project targets. Most features exist in parallel on both; see [Platform
+  Notes](platform-notes/index.md) for where they don't.
+- **`project_type`** (Standard or Template): whether the generated project is a finished,
+  ready-to-code-in repo (**Standard**), or is itself another Copier template that others can copy
+  from in turn (**Template**, which is what produced the very docs you're reading right now). See
+  [Extending This Template](extending-the-template.md) if you're building a Template-type project
+  of your own; that page's "leaf vs. extensible" framing is the natural next decision after this
+  one.
+
+This project inherited its own base layer of automation the same way, from
+[{{ parent_template_name }}]({{ parent_template_url }}). If you build a Template-type project on
+top of it, that child inherits from *you* next, the same relationship one level down. `copier
+update` is what keeps that inheritance flowing: run periodically against a generated project, it
+pulls in whatever changed upstream (new features, fixes, security patches) without discarding
+what's been customized locally. See [Releasing](releasing.md) for what shows up in a project's
+own changelog when that happens.
+
+## What To Read Next
+
+- **Setting this up for the first time?** Keep reading below for installation, then see [Template
+  Questions](template-questions.md) for what each prompt controls.
+- **Adding this to a codebase that already exists?** Skip ahead to [Applying to Existing
+  Projects](applying-to-existing-projects.md).
+- **Extending this template into one of your own?** See [Extending This
+  Template](extending-the-template.md) once you've got it copied and running.
+
+## Installing It
+
 Here's how to use this template:
 
 1. Ensure you have [mise](https://mise.jdx.dev/getting-started.html) installed on your workstation (Linux/macOS/Windows are all supported).

--- a/template/{% if is_template %}docs{% endif %}/lifecycle-management.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/lifecycle-management.md.jinja
@@ -5,11 +5,11 @@ communicated as it changes over time.
 
 ## Choices
 
-- **Pre-Alpha** / **Alpha** — The README displays a notice that the project is not ready for
+- **Pre-Alpha** / **Alpha**: The README displays a notice that the project is not ready for
   public use.
-- **Beta** — The README displays a notice that the project should be used with caution.
-- **Stable** — No notice is shown; the project is considered production-ready.
-- **Inactive** — The README displays a notice that the project is no longer under active
+- **Beta**: The README displays a notice that the project should be used with caution.
+- **Stable**: No notice is shown; the project is considered production-ready.
+- **Inactive**: The README displays a notice that the project is no longer under active
   development.
 
 Changing `lifecycle` via `copier update` updates this notice (or removes it, for Stable)
@@ -18,7 +18,7 @@ automatically.
 ## Moving to Stable for the First Time
 
 While `lifecycle` is Pre-Alpha, Alpha, or Beta, normal commits only ever bump your version's
-minor/patch component — see [Releasing](releasing.md) for how the release flow normally works.
+minor/patch component; see [Releasing](releasing.md) for how the release flow normally works.
 
 Once you set `lifecycle` to `Stable` on a GitHub project (run `mise run set-lifecycle` to change
 just that question), if the version last tracked is still below `1.0.0`, you'll see a message

--- a/template/{% if is_template %}docs{% endif %}/platform-notes/azure-devops.md
+++ b/template/{% if is_template %}docs{% endif %}/platform-notes/azure-devops.md
@@ -20,7 +20,7 @@ Support for Azure DevOps is provided on a best-effort basis and has some limitat
       set this up by hand.
 - `zensical_target` is always `docs-site Directory in Repo`
     - `GitHub Pages` isn't offered, so Azure DevOps projects never get the release-versioned docs
-      site that target provides — see [Getting Started](../index.md#documentation)
+      site that target provides; see [Getting Started](../index.md#documentation)
 - Renovate needs a one-time manual permission grant
     - Unlike GitHub (which uses the Renovate GitHub App), Renovate runs here as a self-hosted
       scheduled pipeline (`.azurepipelines/maint-auto-renovate.yml`), authenticated via the pipeline's own

--- a/template/{% if is_template %}docs{% endif %}/platform-notes/index.md
+++ b/template/{% if is_template %}docs{% endif %}/platform-notes/index.md
@@ -3,5 +3,5 @@
 Each generated project targets one platform (GitHub or Azure DevOps). GitHub has no platform-
 specific quirks or limitations worth calling out here; Azure DevOps does:
 
-- [Azure DevOps Limitations](azure-devops.md) — features unavailable or unimplemented for Azure
+- [Azure DevOps Limitations](azure-devops.md): features unavailable or unimplemented for Azure
   DevOps projects.

--- a/template/{% if is_template %}docs{% endif %}/template-questions.md.jinja
+++ b/template/{% if is_template %}docs{% endif %}/template-questions.md.jinja
@@ -3,13 +3,13 @@
 This page walks through what each Copier question controls, and what it triggers behind the
 scenes. Questions not listed here (`repo_name`, `author_name`, `project_name`,
 `project_description`) are self-explanatory and only affect their own value. Neither platform
-prompts for a token anymore — repo setup uses `gh auth login` (GitHub) or `az login` (Azure
-DevOps) instead — see [Prerequisites](prerequisites.md) and [Token Permissions](token-permissions.md).
+prompts for a token anymore: repo setup uses `gh auth login` (GitHub) or `az login` (Azure
+DevOps) instead; see [Prerequisites](prerequisites.md) and [Token Permissions](token-permissions.md).
 
 ## `developer_platform`: GitHub / Azure DevOps
 
 Determines which platform-specific files get generated: GitHub gets `.github/workflows/`,
-Azure DevOps gets `.azurepipelines/`. This choice also locks out some other options — Azure DevOps
+Azure DevOps gets `.azurepipelines/`. This choice also locks out some other options: Azure DevOps
 projects can't use `GitHub Pages` for `zensical_target`, and `project_visibility` defaults to
 `Private` since Azure DevOps doesn't support public projects the same way. See
 [Azure DevOps Limitations](platform-notes/azure-devops.md) for platform-specific details.
@@ -24,13 +24,13 @@ only) is always generated regardless of this answer; see below. Choosing anythin
 triggers this question's validator, which checks the relevant platform CLI (`gh` or `az`) is
 installed and authenticated *before* letting you proceed; see [Prerequisites](prerequisites.md).
 
-- **Create Repo** — creates the remote repo; on GitHub also sets Actions workflow permissions,
+- **Create Repo**: creates the remote repo; on GitHub also sets Actions workflow permissions,
   sets up GitHub Pages if applicable, and (for public repos) enables CodeQL code scanning's
   default setup and private vulnerability reporting; on Azure DevOps also registers pipelines for
   each file under `.azurepipelines/`.
-- **Set Repo Rules** — skips repo creation (for an existing repo) but still applies the other
+- **Set Repo Rules**: skips repo creation (for an existing repo) but still applies the other
   automation above.
-- **None** — skips all of it; you're on your own for repo creation and settings.
+- **None**: skips all of it; you're on your own for repo creation and settings.
 
 Whichever you choose, GitHub projects still get a generated `.github/settings.yml`, applied
 automatically if you've installed the [Settings GitHub App](https://github.com/apps/settings) (see
@@ -39,10 +39,17 @@ if you haven't. Choosing `None` prints a reminder about this at the end of the r
 
 ## `project_type`: Standard / Template
 
-**Standard** generates a normal project repo. **Template** additionally generates a `copier.yml`
-of its own (so your project can itself be used as a Copier template — this is how this repo
-works), a fuller `docs/` set explaining the template's own features, and template-authoring tasks
-like `mise run integration-test-gh`/`integration-test-azdo`.
+The other foundational decision, alongside `developer_platform`; see [Getting
+Started](index.md#the-two-decisions-that-shape-everything) for why it matters before you even get
+to this question.
+
+**Standard** generates a normal project repo: a finished starting point to build whatever the
+project is actually for. **Template** additionally generates a `copier.yml` of its own (so your
+project can itself be used as a Copier template: this is how this repo works), a fuller `docs/`
+set explaining the template's own features (the page you're reading right now is part of it), and
+template-authoring tasks like `mise run integration-test-gh`/`integration-test-azdo`. See
+[Extending This Template](extending-the-template.md) for what comes after choosing Template here:
+whether your template will itself be extended further, and the checklists for adding to it safely.
 
 ## `project_visibility`: Public / Private
 
@@ -54,7 +61,7 @@ workflow. See [Public vs Private Repos](public-vs-private-repos.md) for the full
 
 Controls whether a `LICENSE` file is generated and whether the README claims MIT licensing. If you
 pick `None` on a Public repo, the README instead shows a notice that the project currently has no
-license set (meaning nobody may legally use, copy, or contribute to it without your permission) —
+license set (meaning nobody may legally use, copy, or contribute to it without your permission);
 see [Public vs Private Repos](public-vs-private-repos.md#support-files). `MIT` isn't offered for Private
 repos, since a license only matters once code is visible to others.
 
@@ -62,9 +69,9 @@ repos, since a license only matters once code is visible to others.
 
 Chooses where rendered documentation ends up:
 
-- **GitHub Pages** — deploys via `docs-auto-zensical.yml`, using `mike` to keep a version-aliased
+- **GitHub Pages**: deploys via `docs-auto-zensical.yml`, using `mike` to keep a version-aliased
   history (`latest`, `dev`, and per-release versions) of the docs site.
-- **docs-site Directory in Repo** — builds via `docs-auto-mkdocs.yml` into a `docs-site/` folder
+- **docs-site Directory in Repo**: builds via `docs-auto-mkdocs.yml` into a `docs-site/` folder
   committed to the repo, always reflecting the latest `main`, with no version history. This is the
   only option for Azure DevOps projects.
 


### PR DESCRIPTION
Getting Started jumped straight to install commands with no orientation. Adds a "The Two Decisions That Shape Everything" section explaining developer_platform/project_type up front, the template inheritance model, and a "What To Read Next" router, plus expands project_type's treatment in Template Questions to match.

Also fixes em dashes in three files an earlier cleanup pass missed: that pass's em-dash search used a regex Git Bash's grep silently failed on, so it never actually ran.