### PR TITLE
fix: backfill legacy version numbers into knope-current-version.json

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -27,6 +27,64 @@ parent_template_url:
 
 # region Migrations
 _migrations:
+  # region Backfill Legacy Version Into knope-current-version.json (0.8.0)
+  # v0.8.0 is what replaced release-please (GitHub) and commitizen (Azure
+  # DevOps) with Knope, introducing knope-current-version.json. A project
+  # updating past that point tracked its version via one of those two tools
+  # or their own predecessor commit-and-tag-version instead -- but all
+  # three tag releases as `vX.Y.Z` the same way Knope does, so the latest
+  # git tag is the real version regardless of which one was in use; no
+  # need to detect which. The file is seeded with a "0.0.0" placeholder the
+  # moment a project first receives it, same as any other new template
+  # file, so this only overwrites that placeholder, never a real version.
+  - command:
+      - mise
+      - x
+      - --
+      - python
+      - -c
+      - |
+        import json
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        version_file = Path(".config/knope-current-version.json")
+        if version_file.is_file():
+            try:
+                current = json.loads(
+                    version_file.read_text(encoding="utf-8")
+                ).get("version")
+            except (json.JSONDecodeError, OSError):
+                current = None
+            if current != "0.0.0":
+                sys.exit(0)
+
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--abbrev=0"],
+            capture_output=True, text=True, check=False,
+        )
+        if result.returncode != 0:
+            sys.exit(0)
+        version = result.stdout.strip().lstrip("v")
+
+        version_file.parent.mkdir(exist_ok=True)
+        version_file.write_text(
+            json.dumps(
+                {
+                    "_comment": "Managed by Knope; do not edit manually.",
+                    "version": version,
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        print(f"Backfilled legacy version {version!r} into knope-current-version.json.")
+    version: v0.8.0
+    when: "{{ _stage == 'after' }}"
+  # endregion Backfill Legacy Version Into knope-current-version.json (0.8.0)
+
   # region Knope Changelog Reformatter (0.8.1)
   # release-please wrote CHANGELOG.md headings as `## [X.Y.Z](url) (date)`, which
   # Knope's changelog writer can't parse; it silently appends new releases at the

--- a/template/{% if is_template %}copier.yml{% endif %}.jinja
+++ b/template/{% if is_template %}copier.yml{% endif %}.jinja
@@ -40,6 +40,64 @@ parent_template_url:
 
 # region Migrations
 _migrations:
+  # region Backfill Legacy Version Into knope-current-version.json (0.8.0)
+  # v0.8.0 is what replaced release-please (GitHub) and commitizen (Azure
+  # DevOps) with Knope, introducing knope-current-version.json. A project
+  # updating past that point tracked its version via one of those two tools
+  # or their own predecessor commit-and-tag-version instead -- but all
+  # three tag releases as `vX.Y.Z` the same way Knope does, so the latest
+  # git tag is the real version regardless of which one was in use; no
+  # need to detect which. The file is seeded with a "0.0.0" placeholder the
+  # moment a project first receives it, same as any other new template
+  # file, so this only overwrites that placeholder, never a real version.
+  - command:
+      - mise
+      - x
+      - --
+      - python
+      - -c
+      - |
+        import json
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        version_file = Path(".config/knope-current-version.json")
+        if version_file.is_file():
+            try:
+                current = json.loads(
+                    version_file.read_text(encoding="utf-8")
+                ).get("version")
+            except (json.JSONDecodeError, OSError):
+                current = None
+            if current != "0.0.0":
+                sys.exit(0)
+
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--abbrev=0"],
+            capture_output=True, text=True, check=False,
+        )
+        if result.returncode != 0:
+            sys.exit(0)
+        version = result.stdout.strip().lstrip("v")
+
+        version_file.parent.mkdir(exist_ok=True)
+        version_file.write_text(
+            json.dumps(
+                {
+                    "_comment": "Managed by Knope; do not edit manually.",
+                    "version": version,
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        print(f"Backfilled legacy version {version!r} into knope-current-version.json.")
+    version: v0.8.0
+    when: "{{ _stage == 'after' }}"
+  # endregion Backfill Legacy Version Into knope-current-version.json (0.8.0)
+
   # region Knope Changelog Reformatter (0.8.1)
   # release-please wrote CHANGELOG.md headings as `## [X.Y.Z](url) (date)`, which
   # Knope's changelog writer can't parse; it silently appends new releases at the


### PR DESCRIPTION
A project that predates v0.8.0 tracked its version via release-please, commitizen, or their own predecessor commit-and-tag-version instead of Knope. All three tag releases as vX.Y.Z the same way Knope does, so this reads the latest git tag as the real version rather than trying to detect and parse each tool's own config format.

Gated to v0.8.0, the release that actually replaced those three tools with Knope, and guarded on knope-current-version.json still holding its "0.0.0" seed placeholder, so it only ever overwrites that, never a real version a project already has.